### PR TITLE
Optimize port communication for scalar types

### DIFF
--- a/examples/count/main.cc
+++ b/examples/count/main.cc
@@ -37,13 +37,13 @@ public:
 };
 
 auto main() -> int {
-  Environment e{4, true};
+  Environment env{4, true};
 
-  Count count{&e};
-  e.assemble();
+  Count count{&env};
+  env.assemble();
 
-  auto t = e.startup();
-  t.join();
+  auto thread = env.startup();
+  thread.join();
 
   return 0;
 }

--- a/examples/hello/main.cc
+++ b/examples/hello/main.cc
@@ -44,14 +44,14 @@ public:
 };
 
 auto main() -> int {
-  Environment e{4};
+  Environment env{4};
 
-  Hello hello{&e};
-  Timeout timeout{&e, 5s};
-  e.assemble();
+  Hello hello{&env};
+  Timeout timeout{&env, 5s};
+  env.assemble();
 
-  auto t = e.startup();
-  t.join();
+  auto thread = env.startup();
+  thread.join();
 
   return 0;
 }

--- a/examples/ports/main.cc
+++ b/examples/ports/main.cc
@@ -89,30 +89,30 @@ public:
 };
 
 auto main() -> int {
-  Environment e{4};
+  Environment env{4};
 
-  Trigger t1{"t1", &e, 1s};
-  Counter c1{"c1", &e};
-  Printer p1{"p1", &e};
-  t1.trigger.bind_to(&c1.trigger);
-  c1.count.bind_to(&p1.value);
+  Trigger trigger1{"t1", &env, 1s};
+  Counter counter1{"c1", &env};
+  Printer printer1{"p1", &env};
+  trigger1.trigger.bind_to(&counter1.trigger);
+  counter1.count.bind_to(&printer1.value);
 
-  Trigger t2{"t2", &e, 2s};
-  Counter c2{"c2", &e};
-  Printer p2{"p2", &e};
-  t2.trigger.bind_to(&c2.trigger);
-  c2.count.bind_to(&p2.value);
+  Trigger trigger2{"t2", &env, 2s};
+  Counter counter2{"c2", &env};
+  Printer printer2{"p2", &env};
+  trigger2.trigger.bind_to(&counter2.trigger);
+  counter2.count.bind_to(&printer2.value);
 
-  Adder add{"add", &e};
-  Printer p_add{"p_add", &e};
-  c1.count.bind_to(&add.i1);
-  c2.count.bind_to(&add.i2);
+  Adder add{"add", &env};
+  Printer p_add{"p_add", &env};
+  counter1.count.bind_to(&add.i1);
+  counter2.count.bind_to(&add.i2);
   add.sum.bind_to(&p_add.value);
 
-  e.assemble();
+  env.assemble();
 
-  auto t = e.startup();
-  t.join();
+  auto thread = env.startup();
+  thread.join();
 
   return 0;
 }

--- a/examples/power_train/main.cc
+++ b/examples/power_train/main.cc
@@ -155,16 +155,16 @@ public:
 };
 
 auto main() -> int {
-  Environment e{4};
+  Environment env{4};
 
-  LeftPedal left_pedal{&e};
-  RightPedal right_pedal{&e};
-  BrakeControl brake_control{&e};
-  EngineControl engine_control{&e};
-  Brake brakes{&e};
-  Engine engine{&e};
+  LeftPedal left_pedal{&env};
+  RightPedal right_pedal{&env};
+  BrakeControl brake_control{&env};
+  EngineControl engine_control{&env};
+  Brake brakes{&env};
+  Engine engine{&env};
 
-  e.assemble();
+  env.assemble();
   left_pedal.angle.bind_to(&brake_control.angle);
   left_pedal.on_off.bind_to(&engine_control.on_off);
   brake_control.force.bind_to(&brakes.force);
@@ -172,10 +172,10 @@ auto main() -> int {
   engine_control.check.bind_to(&right_pedal.check);
   engine_control.torque.bind_to(&engine.torque);
 
-  e.export_dependency_graph("graph.dot");
+  env.export_dependency_graph("graph.dot");
 
-  auto t = e.startup();
-  t.join();
+  auto thread = env.startup();
+  thread.join();
 
   return 0;
 }

--- a/include/reactor-cpp/value_ptr.hh
+++ b/include/reactor-cpp/value_ptr.hh
@@ -276,8 +276,8 @@ public:
 
   // Give the factory function make_mutable_value() access to the private
   // constructor
-  // NOLINTNEXTLINE(readability-redundant-declaration)
   template <class U, class... Args>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
   friend auto reactor::make_mutable_value(Args&&... args) -> reactor::MutableValuePtr<U>;
 };
 
@@ -468,8 +468,8 @@ public:
 
   // Give the factory function make_mutable_value() access to the private
   // constructor
-  // NOLINTNEXTLINE(readability-redundant-declaration)
   template <class U, class... Args>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
   friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
 };
 
@@ -516,8 +516,8 @@ public:
 
   // Give the factory function make_mutable_value() access to the private
   // constructor
-  // NOLINTNEXTLINE(readability-redundant-declaration)
   template <class U, class... Args>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
   friend auto reactor::make_mutable_value(Args&&... args) -> reactor::MutableValuePtr<U>;
 };
 
@@ -563,8 +563,8 @@ public:
 
   // Give the factory function make_mutable_value() access to the private
   // constructor
-  // NOLINTNEXTLINE(readability-redundant-declaration)
   template <class U, class... Args>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
   friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
 };
 

--- a/include/reactor-cpp/value_ptr.hh
+++ b/include/reactor-cpp/value_ptr.hh
@@ -48,7 +48,7 @@ template <class T, class... Args> auto make_immutable_value(Args&&... args) -> I
   if constexpr (std::is_scalar<T>::value) {
     return ImmutableValuePtr<T>(T(std::forward<Args>(args)...));
   } else {
-    return ImmutableValuePtr<T>(new T(std::forward<Args>(args)...));
+    return ImmutableValuePtr<T>(std::make_shared<T>(std::forward<Args>(args)...));
   }
 }
 
@@ -71,7 +71,7 @@ template <class T, class... Args> auto make_mutable_value(Args&&... args) -> Mut
   if constexpr (std::is_scalar<T>::value) {
     return MutableValuePtr<T>(T(std::forward<Args>(args)...));
   } else {
-    return MutableValuePtr<T>(new T(std::forward<Args>(args)...));
+    return MutableValuePtr<T>(std::make_unique<T>(std::forward<Args>(args)...));
   }
 }
 
@@ -167,8 +167,8 @@ private:
    * :func:`make_immutable_copy()` method of :class:`ImmutableValuePtr`.
    * @endrst
    */
-  explicit MutableValuePtr(T* value)
-      : internal_ptr(value) {}
+  explicit MutableValuePtr(std::unique_ptr<T>&& value)
+      : internal_ptr(std::move(value)) {}
 
 public:
   /**
@@ -316,8 +316,8 @@ private:
    * :func:`make_immutable_value()` factory function.
    * @endrst
    */
-  explicit ImmutableValuePtr(T* value)
-      : internal_ptr(value) {}
+  explicit ImmutableValuePtr(std::shared_ptr<T>&& value)
+      : internal_ptr(std::move(value)) {}
 
 public:
   /**
@@ -463,7 +463,7 @@ public:
    * @return a mutable value pointer
    */
   [[nodiscard]] auto get_mutable_copy() const -> MutableValuePtr<T, false> {
-    return MutableValuePtr<T, false>(new T(*internal_ptr));
+    return MutableValuePtr<T, false>(std::make_unique<T>(*internal_ptr));
   }
 
   // Give the factory function make_mutable_value() access to the private

--- a/include/reactor-cpp/value_ptr.hh
+++ b/include/reactor-cpp/value_ptr.hh
@@ -24,6 +24,110 @@ namespace detail {
 template <class T, bool is_scalar> class ImmutableValuePtr {};
 template <class T, bool is_scalar> class MutableValuePtr {};
 
+} // namespace detail
+
+template <class T> using MutableValuePtr = detail::MutableValuePtr<T, std::is_scalar<T>::value>;
+template <class T> using ImmutableValuePtr = detail::ImmutableValuePtr<T, std::is_scalar<T>::value>;
+
+/**
+ * @rst
+ * Create an instance of :class:`ImmutableValuePtr`.
+ *
+ * Creates and initializes a new instance of ``T`` and returns a new
+ * :class:`ImmutableValuePtr` owning this value. This is analogues to
+ * :std-memory:`make_shared`
+ * @endrst
+ * @tparam T type of the value to be created
+ * @tparam Args types of ``T``'s constructor arguments. Usually, this does not
+ * need to be given explicitly and will be inferred automatically from the
+ * given ``args``.
+ * @param args Arguments to be forwarded to ``T``'s constructor
+ * @return a new immutable value pointer
+ */
+template <class T, class... Args> auto make_immutable_value(Args&&... args) -> ImmutableValuePtr<T> {
+  return ImmutableValuePtr<T>(new T(std::forward<Args>(args)...));
+}
+
+/**
+ * @rst
+ * Create an instance of :class:`MutableValuePtr`.
+
+ * Creates and initializes a new instance of ``T`` and returns a new
+ * :class:`MutableValuePtr` owning this value. This is analogues to
+ * :std-memory:`make_unique`.
+ * @endrst
+ * @tparam T type of the value to be created
+ * @tparam Args types of ``T``'s constructor arguments. Usually, this does not
+ * need to be given explicitly and will be inferred automatically from the
+ * given ``args``.
+ * @param args Arguments to be forwarded to ``T``'s constructor
+ * @return a new mutable value pointer
+ */
+template <class T, class... Args> auto make_mutable_value(Args&&... args) -> MutableValuePtr<T> {
+  return MutableValuePtr<T>(new T(std::forward<Args>(args)...));
+}
+
+// Comparison operators
+
+template <class T, class U>
+auto operator==(const MutableValuePtr<T>& ptr1, const MutableValuePtr<U>& ptr2) noexcept -> bool {
+  return ptr1.get() == ptr2.get();
+}
+template <class T, class U>
+auto operator==(const ImmutableValuePtr<T>& ptr1, const ImmutableValuePtr<U>& ptr2) noexcept -> bool {
+  return ptr1.get() == ptr2.get();
+}
+template <class T, class U>
+auto operator==(const ImmutableValuePtr<T>& ptr1, const MutableValuePtr<U>& ptr2) noexcept -> bool {
+  return ptr1.get() == ptr2.get();
+}
+template <class T, class U>
+auto operator==(const MutableValuePtr<T>& ptr1, const ImmutableValuePtr<U>& ptr2) noexcept -> bool {
+  return ptr1.get() == ptr2.get();
+}
+template <class T> auto operator==(const MutableValuePtr<T>& ptr1, std::nullptr_t) noexcept -> bool {
+  return ptr1.get() == nullptr;
+}
+template <class T> auto operator==(std::nullptr_t, const MutableValuePtr<T>& ptr2) noexcept -> bool {
+  return ptr2.get() == nullptr;
+}
+template <class T> auto operator==(const ImmutableValuePtr<T>& ptr1, std::nullptr_t) noexcept -> bool {
+  return ptr1.get() == nullptr;
+}
+template <class T> auto operator==(std::nullptr_t, const ImmutableValuePtr<T>& ptr1) noexcept -> bool {
+  return ptr1.get() == nullptr;
+}
+
+template <class T, class U>
+auto operator!=(const MutableValuePtr<T>& ptr1, const MutableValuePtr<U>& ptr2) noexcept -> bool {
+  return ptr1.get() != ptr2.get();
+}
+
+template <class T, class U>
+auto operator!=(const ImmutableValuePtr<T>& ptr1, const ImmutableValuePtr<U>& ptr2) -> bool {
+  return ptr1.get() != ptr2.get();
+}
+template <class T, class U> auto operator!=(const ImmutableValuePtr<T>& ptr1, const MutableValuePtr<U>& ptr2) -> bool {
+  return ptr1.get() != ptr2.get();
+}
+template <class T, class U> auto operator!=(const MutableValuePtr<T>& ptr1, const ImmutableValuePtr<U>& ptr2) -> bool {
+  return ptr1.get() != ptr2.get();
+}
+template <class T> auto operator!=(const MutableValuePtr<T>& ptr1, std::nullptr_t) -> bool {
+  return ptr1.get() != nullptr;
+}
+template <class T> auto operator!=(std::nullptr_t, const MutableValuePtr<T>& ptr1) -> bool {
+  return ptr1.get() != nullptr;
+}
+template <class T> auto operator!=(const ImmutableValuePtr<T>& ptr1, std::nullptr_t) -> bool {
+  return ptr1.get() != nullptr;
+}
+template <class T> auto operator!=(std::nullptr_t, const ImmutableValuePtr<T>& ptr1) -> bool {
+  return ptr1.get() != nullptr;
+}
+
+namespace detail {
+
 /**
  * @brief Smart pointer to a mutable value.
  *
@@ -165,7 +269,7 @@ public:
   // Give the factory function make_mutable_value() access to the private
   // constructor
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  template <class U, class... Args> friend auto make_mutable_value(Args&&... args) -> MutableValuePtr<U, false>;
+  template <class U, class... Args> friend auto reactor::make_mutable_value(Args&&... args) -> reactor::MutableValuePtr<U>;
 };
 
 /**
@@ -356,10 +460,8 @@ public:
   // Give the factory function make_mutable_value() access to the private
   // constructor
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  template <class U, class... Args> friend auto make_immutable_value(Args&&... args) -> ImmutableValuePtr<U, false>;
+  template <class U, class... Args> friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
 };
-
-
 
 template <class T> class MutableValuePtr<T, true> {
 private:
@@ -408,7 +510,7 @@ public:
   // Give the factory function make_mutable_value() access to the private
   // constructor
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  template <class U, class... Args> friend auto make_mutable_value(Args&&... args) -> MutableValuePtr<U, true>;
+  template <class U, class... Args> friend auto reactor::make_mutable_value(Args&&... args) -> reactor::MutableValuePtr<U>;
 };
 
 template <class T> class ImmutableValuePtr<T, true> {
@@ -435,7 +537,8 @@ public:
 
   explicit constexpr ImmutableValuePtr(std::nullptr_t) {}
   explicit ImmutableValuePtr(MutableValuePtr<T, false>&& ptr)
-    : value_(ptr.value_), valid_(ptr.valid_) {}
+      : value_(ptr.value_)
+      , valid_(ptr.valid_) {}
 
   auto operator=(std::nullptr_t) -> ImmutableValuePtr& {
     this->valid_ = false;
@@ -451,117 +554,15 @@ public:
   auto operator*() const -> const_T& { return value_; }
   auto operator->() const -> const_T* { return get(); }
 
-  [[nodiscard]] auto get_mutable_copy() const -> MutableValuePtr<T, true> {
-    return MutableValuePtr<T, true>(get());
-  }
+  [[nodiscard]] auto get_mutable_copy() const -> MutableValuePtr<T, true> { return MutableValuePtr<T, true>(get()); }
 
   // Give the factory function make_mutable_value() access to the private
   // constructor
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  template <class U, class... Args> friend auto make_immutable_value(Args&&... args) -> ImmutableValuePtr<U, true>;
+  template <class U, class... Args> friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
 };
 
 } // namespace detail
-
-template <class T> using MutableValuePtr = detail::MutableValuePtr<T, std::is_scalar<T>::value>;
-template <class T> using ImmutableValuePtr = detail::ImmutableValuePtr<T, std::is_scalar<T>::value>;
-
-/**
- * @rst
- * Create an instance of :class:`ImmutableValuePtr`.
- *
- * Creates and initializes a new instance of ``T`` and returns a new
- * :class:`ImmutableValuePtr` owning this value. This is analogues to
- * :std-memory:`make_shared`
- * @endrst
- * @tparam T type of the value to be created
- * @tparam Args types of ``T``'s constructor arguments. Usually, this does not
- * need to be given explicitly and will be inferred automatically from the
- * given ``args``.
- * @param args Arguments to be forwarded to ``T``'s constructor
- * @return a new immutable value pointer
- */
-template <class T, class... Args> auto make_immutable_value(Args&&... args) -> ImmutableValuePtr<T> {
-  return ImmutableValuePtr<T>(new T(std::forward<Args>(args)...));
-}
-
-/**
- * @rst
- * Create an instance of :class:`MutableValuePtr`.
-
- * Creates and initializes a new instance of ``T`` and returns a new
- * :class:`MutableValuePtr` owning this value. This is analogues to
- * :std-memory:`make_unique`.
- * @endrst
- * @tparam T type of the value to be created
- * @tparam Args types of ``T``'s constructor arguments. Usually, this does not
- * need to be given explicitly and will be inferred automatically from the
- * given ``args``.
- * @param args Arguments to be forwarded to ``T``'s constructor
- * @return a new mutable value pointer
- */
-template <class T, class... Args> auto make_mutable_value(Args&&... args) -> MutableValuePtr<T> {
-  return MutableValuePtr<T>(new T(std::forward<Args>(args)...));
-}
-
-// Comparison operators
-
-template <class T, class U>
-auto operator==(const MutableValuePtr<T>& ptr1, const MutableValuePtr<U>& ptr2) noexcept -> bool {
-  return ptr1.get() == ptr2.get();
-}
-template <class T, class U>
-auto operator==(const ImmutableValuePtr<T>& ptr1, const ImmutableValuePtr<U>& ptr2) noexcept -> bool {
-  return ptr1.get() == ptr2.get();
-}
-template <class T, class U>
-auto operator==(const ImmutableValuePtr<T>& ptr1, const MutableValuePtr<U>& ptr2) noexcept -> bool {
-  return ptr1.get() == ptr2.get();
-}
-template <class T, class U>
-auto operator==(const MutableValuePtr<T>& ptr1, const ImmutableValuePtr<U>& ptr2) noexcept -> bool {
-  return ptr1.get() == ptr2.get();
-}
-template <class T> auto operator==(const MutableValuePtr<T>& ptr1, std::nullptr_t) noexcept -> bool {
-  return ptr1.get() == nullptr;
-}
-template <class T> auto operator==(std::nullptr_t, const MutableValuePtr<T>& ptr2) noexcept -> bool {
-  return ptr2.get() == nullptr;
-}
-template <class T> auto operator==(const ImmutableValuePtr<T>& ptr1, std::nullptr_t) noexcept -> bool {
-  return ptr1.get() == nullptr;
-}
-template <class T> auto operator==(std::nullptr_t, const ImmutableValuePtr<T>& ptr1) noexcept -> bool {
-  return ptr1.get() == nullptr;
-}
-
-template <class T, class U>
-auto operator!=(const MutableValuePtr<T>& ptr1, const MutableValuePtr<U>& ptr2) noexcept -> bool {
-  return ptr1.get() != ptr2.get();
-}
-
-template <class T, class U>
-auto operator!=(const ImmutableValuePtr<T>& ptr1, const ImmutableValuePtr<U>& ptr2) -> bool {
-  return ptr1.get() != ptr2.get();
-}
-template <class T, class U> auto operator!=(const ImmutableValuePtr<T>& ptr1, const MutableValuePtr<U>& ptr2) -> bool {
-  return ptr1.get() != ptr2.get();
-}
-template <class T, class U> auto operator!=(const MutableValuePtr<T>& ptr1, const ImmutableValuePtr<U>& ptr2) -> bool {
-  return ptr1.get() != ptr2.get();
-}
-template <class T> auto operator!=(const MutableValuePtr<T>& ptr1, std::nullptr_t) -> bool {
-  return ptr1.get() != nullptr;
-}
-template <class T> auto operator!=(std::nullptr_t, const MutableValuePtr<T>& ptr1) -> bool {
-  return ptr1.get() != nullptr;
-}
-template <class T> auto operator!=(const ImmutableValuePtr<T>& ptr1, std::nullptr_t) -> bool {
-  return ptr1.get() != nullptr;
-}
-template <class T> auto operator!=(std::nullptr_t, const ImmutableValuePtr<T>& ptr1) -> bool {
-  return ptr1.get() != nullptr;
-}
 
 } // namespace reactor
 

--- a/include/reactor-cpp/value_ptr.hh
+++ b/include/reactor-cpp/value_ptr.hh
@@ -24,6 +24,12 @@ namespace detail {
 template <class T, bool is_scalar> class ImmutableValuePtr {};
 template <class T, bool is_scalar> class MutableValuePtr {};
 
+template <class T, bool is_scalar, class... Args>
+auto make_immutable_value(Args&&... args) -> ImmutableValuePtr<T, is_scalar>;
+
+template <class T, bool is_scalar, class... Args>
+auto make_mutable_value(Args&&... args) -> MutableValuePtr<T, is_scalar>;
+
 } // namespace detail
 
 template <class T> using MutableValuePtr = detail::MutableValuePtr<T, std::is_scalar<T>::value>;
@@ -45,7 +51,7 @@ template <class T> using ImmutableValuePtr = detail::ImmutableValuePtr<T, std::i
  * @return a new immutable value pointer
  */
 template <class T, class... Args> auto make_immutable_value(Args&&... args) -> ImmutableValuePtr<T> {
-  return ImmutableValuePtr<T>(new T(std::forward<Args>(args)...));
+  return detail::make_immutable_value<T, std::is_scalar<T>::value, Args...>(args...);
 }
 
 /**
@@ -64,7 +70,7 @@ template <class T, class... Args> auto make_immutable_value(Args&&... args) -> I
  * @return a new mutable value pointer
  */
 template <class T, class... Args> auto make_mutable_value(Args&&... args) -> MutableValuePtr<T> {
-  return MutableValuePtr<T>(new T(std::forward<Args>(args)...));
+  return detail::make_mutable_value<T, std::is_scalar<T>::value, Args...>(args...);
 }
 
 // Comparison operators
@@ -269,7 +275,8 @@ public:
   // Give the factory function make_mutable_value() access to the private
   // constructor
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  template <class U, class... Args> friend auto reactor::make_mutable_value(Args&&... args) -> reactor::MutableValuePtr<U>;
+  template <class U, class... Args>
+  friend auto reactor::make_mutable_value(Args&&... args) -> reactor::MutableValuePtr<U>;
 };
 
 /**
@@ -460,7 +467,8 @@ public:
   // Give the factory function make_mutable_value() access to the private
   // constructor
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  template <class U, class... Args> friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
+  template <class U, class... Args>
+  friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
 };
 
 template <class T> class MutableValuePtr<T, true> {
@@ -510,7 +518,8 @@ public:
   // Give the factory function make_mutable_value() access to the private
   // constructor
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  template <class U, class... Args> friend auto reactor::make_mutable_value(Args&&... args) -> reactor::MutableValuePtr<U>;
+  template <class U, class... Args>
+  friend auto reactor::make_mutable_value(Args&&... args) -> reactor::MutableValuePtr<U>;
 };
 
 template <class T> class ImmutableValuePtr<T, true> {
@@ -559,8 +568,25 @@ public:
   // Give the factory function make_mutable_value() access to the private
   // constructor
   // NOLINTNEXTLINE(readability-redundant-declaration)
-  template <class U, class... Args> friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
+  template <class U, class... Args>
+  friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
 };
+
+template <class T, class... Args> auto make_immutable_value(Args&&... args) -> ImmutableValuePtr<T, false> {
+  return ImmutableValuePtr<T, false>(new T(std::forward<Args>(args)...));
+}
+
+template <class T, class... Args> auto make_immutable_value(Args&&... args) -> ImmutableValuePtr<T, true> {
+  return ImmutableValuePtr<T, true>(T(std::forward<Args>(args)...));
+}
+
+template <class T, class... Args> auto make_mutable_value(Args&&... args) -> MutableValuePtr<T, false> {
+  return MutableValuePtr<T, false>(new T(std::forward<Args>(args)...));
+}
+
+template <class T, class... Args> auto make_mutable_value(Args&&... args) -> MutableValuePtr<T, true> {
+  return MutableValuePtr<T, true>(T(std::forward<Args>(args)...));
+}
 
 } // namespace detail
 


### PR DESCRIPTION
In reactor-cpp, every value relayed via ports and stored in actions is wrapped in a value ptr. The value ptr itself is a wrapper around the smart pointers of the stdlib and extends it by control for mutability. However, a smartpointer adds a small (but still significant) overhead if simple data types such as scalar values are used. This PR provides two different template specializations that implement the value ptr interface. The old one (based on smart pointers) is only used for non-scalar types. For all scalar types, a new optimized specialization is added that simply stores the value directly instead of using a smartpointer.

On my laptop, this improved performance of the RadixSort benchmark by about 1.7x. Other benchmarks likely also benefit from the change, but maybe not as much.