### PR TITLE
optimize value pointers for trivially copyable types

### DIFF
--- a/include/reactor-cpp/value_ptr.hh
+++ b/include/reactor-cpp/value_ptr.hh
@@ -30,7 +30,7 @@ template <class T, bool is_trivial> class MutableValuePtr {};
 constexpr std::size_t SIZE_THRESHOLD = 64;
 
 template <class T> constexpr auto is_trivial() -> bool {
-  return std::is_trivially_copyable<T>::value && sizeof(T) <= SIZE_THRESHOLD;
+  return std::is_default_constructible<T>::value && std::is_trivially_copyable<T>::value && sizeof(T) <= SIZE_THRESHOLD;
 }
 
 } // namespace detail

--- a/include/reactor-cpp/value_ptr.hh
+++ b/include/reactor-cpp/value_ptr.hh
@@ -428,7 +428,7 @@ private:
   T value_{};
   bool valid_{false};
 
-  explicit MutableValuePtr(const T value)
+  explicit MutableValuePtr(const T& value)
       : value_{value}
       , valid_{true} {}
 
@@ -509,7 +509,7 @@ public:
   auto operator*() const -> const_T& { return value_; }
   auto operator->() const -> const_T* { return get(); }
 
-  [[nodiscard]] auto get_mutable_copy() const -> MutableValuePtr<T, true> { return MutableValuePtr<T, true>(get()); }
+  [[nodiscard]] auto get_mutable_copy() const -> MutableValuePtr<T, true> { return MutableValuePtr<T, true>(*get()); }
 
   // Give the factory function make_mutable_value() access to the private
   // constructor

--- a/include/reactor-cpp/value_ptr.hh
+++ b/include/reactor-cpp/value_ptr.hh
@@ -491,7 +491,7 @@ public:
   ImmutableValuePtr(ImmutableValuePtr&& ptr) noexcept = default;
 
   explicit constexpr ImmutableValuePtr(std::nullptr_t) {}
-  explicit ImmutableValuePtr(MutableValuePtr<T, false>&& ptr)
+  explicit ImmutableValuePtr(MutableValuePtr<T, true>&& ptr)
       : value_(ptr.value_)
       , valid_(ptr.valid_) {}
 
@@ -520,66 +520,75 @@ public:
 
 // Comparison operators
 
-template <class T, class U, bool scalar>
-auto operator==(const MutableValuePtr<T, scalar>& ptr1, const MutableValuePtr<U, scalar>& ptr2) noexcept -> bool {
+template <class T, class U, bool is_trivial>
+auto operator==(const MutableValuePtr<T, is_trivial>& ptr1, const MutableValuePtr<U, is_trivial>& ptr2) noexcept
+    -> bool {
   return ptr1.get() == ptr2.get();
 }
-template <class T, class U, bool scalar>
-auto operator==(const ImmutableValuePtr<T, scalar>& ptr1, const ImmutableValuePtr<U, scalar>& ptr2) noexcept -> bool {
+template <class T, class U, bool is_trivial>
+auto operator==(const ImmutableValuePtr<T, is_trivial>& ptr1, const ImmutableValuePtr<U, is_trivial>& ptr2) noexcept
+    -> bool {
   return ptr1.get() == ptr2.get();
 }
-template <class T, class U, bool scalar>
-auto operator==(const ImmutableValuePtr<T, scalar>& ptr1, const MutableValuePtr<U, scalar>& ptr2) noexcept -> bool {
+template <class T, class U, bool is_trivial>
+auto operator==(const ImmutableValuePtr<T, is_trivial>& ptr1, const MutableValuePtr<U, is_trivial>& ptr2) noexcept
+    -> bool {
   return ptr1.get() == ptr2.get();
 }
-template <class T, class U, bool scalar>
-auto operator==(const MutableValuePtr<T, scalar>& ptr1, const ImmutableValuePtr<U, scalar>& ptr2) noexcept -> bool {
+template <class T, class U, bool is_trivial>
+auto operator==(const MutableValuePtr<T, is_trivial>& ptr1, const ImmutableValuePtr<U, is_trivial>& ptr2) noexcept
+    -> bool {
   return ptr1.get() == ptr2.get();
 }
-template <class T, bool scalar>
-auto operator==(const MutableValuePtr<T, scalar>& ptr1, std::nullptr_t) noexcept -> bool {
+template <class T, bool is_trivial>
+auto operator==(const MutableValuePtr<T, is_trivial>& ptr1, std::nullptr_t) noexcept -> bool {
   return ptr1.get() == nullptr;
 }
-template <class T, bool scalar>
-auto operator==(std::nullptr_t, const MutableValuePtr<T, scalar>& ptr2) noexcept -> bool {
+template <class T, bool is_trivial>
+auto operator==(std::nullptr_t, const MutableValuePtr<T, is_trivial>& ptr2) noexcept -> bool {
   return ptr2.get() == nullptr;
 }
-template <class T, bool scalar>
-auto operator==(const ImmutableValuePtr<T, scalar>& ptr1, std::nullptr_t) noexcept -> bool {
+template <class T, bool is_trivial>
+auto operator==(const ImmutableValuePtr<T, is_trivial>& ptr1, std::nullptr_t) noexcept -> bool {
   return ptr1.get() == nullptr;
 }
-template <class T, bool scalar>
-auto operator==(std::nullptr_t, const ImmutableValuePtr<T, scalar>& ptr1) noexcept -> bool {
+template <class T, bool is_trivial>
+auto operator==(std::nullptr_t, const ImmutableValuePtr<T, is_trivial>& ptr1) noexcept -> bool {
   return ptr1.get() == nullptr;
 }
 
-template <class T, class U, bool scalar>
-auto operator!=(const MutableValuePtr<T, scalar>& ptr1, const MutableValuePtr<U, scalar>& ptr2) noexcept -> bool {
+template <class T, class U, bool is_trivial>
+auto operator!=(const MutableValuePtr<T, is_trivial>& ptr1, const MutableValuePtr<U, is_trivial>& ptr2) noexcept
+    -> bool {
   return ptr1.get() != ptr2.get();
 }
 
-template <class T, class U, bool scalar>
-auto operator!=(const ImmutableValuePtr<T, scalar>& ptr1, const ImmutableValuePtr<U, scalar>& ptr2) -> bool {
+template <class T, class U, bool is_trivial>
+auto operator!=(const ImmutableValuePtr<T, is_trivial>& ptr1, const ImmutableValuePtr<U, is_trivial>& ptr2) -> bool {
   return ptr1.get() != ptr2.get();
 }
-template <class T, class U, bool scalar>
-auto operator!=(const ImmutableValuePtr<T, scalar>& ptr1, const MutableValuePtr<U, scalar>& ptr2) -> bool {
+template <class T, class U, bool is_trivial>
+auto operator!=(const ImmutableValuePtr<T, is_trivial>& ptr1, const MutableValuePtr<U, is_trivial>& ptr2) -> bool {
   return ptr1.get() != ptr2.get();
 }
-template <class T, class U, bool scalar>
-auto operator!=(const MutableValuePtr<T, scalar>& ptr1, const ImmutableValuePtr<U, scalar>& ptr2) -> bool {
+template <class T, class U, bool is_trivial>
+auto operator!=(const MutableValuePtr<T, is_trivial>& ptr1, const ImmutableValuePtr<U, is_trivial>& ptr2) -> bool {
   return ptr1.get() != ptr2.get();
 }
-template <class T, bool scalar> auto operator!=(const MutableValuePtr<T, scalar>& ptr1, std::nullptr_t) -> bool {
+template <class T, bool is_trivial>
+auto operator!=(const MutableValuePtr<T, is_trivial>& ptr1, std::nullptr_t) -> bool {
   return ptr1.get() != nullptr;
 }
-template <class T, bool scalar> auto operator!=(std::nullptr_t, const MutableValuePtr<T, scalar>& ptr1) -> bool {
+template <class T, bool is_trivial>
+auto operator!=(std::nullptr_t, const MutableValuePtr<T, is_trivial>& ptr1) -> bool {
   return ptr1.get() != nullptr;
 }
-template <class T, bool scalar> auto operator!=(const ImmutableValuePtr<T, scalar>& ptr1, std::nullptr_t) -> bool {
+template <class T, bool is_trivial>
+auto operator!=(const ImmutableValuePtr<T, is_trivial>& ptr1, std::nullptr_t) -> bool {
   return ptr1.get() != nullptr;
 }
-template <class T, bool scalar> auto operator!=(std::nullptr_t, const ImmutableValuePtr<T, scalar>& ptr1) -> bool {
+template <class T, bool is_trivial>
+auto operator!=(std::nullptr_t, const ImmutableValuePtr<T, is_trivial>& ptr1) -> bool {
   return ptr1.get() != nullptr;
 }
 

--- a/lib/port.cc
+++ b/lib/port.cc
@@ -18,7 +18,6 @@ void BasePort::base_bind_to(BasePort* port) {
   reactor_assert(port != nullptr);
   reactor_assert(this->environment() == port->environment()); // NOLINT
   validate(!port->has_inward_binding(), "Ports may only be connected once");
-  validate(!this->has_dependencies(), "Ports with dependencies may not be connected to other ports");
   validate(!port->has_antidependencies(), "Ports with antidependencies may not be connected to other ports");
   assert_phase(this, Environment::Phase::Assembly);
   if (this->is_input() && port->is_input()) {


### PR DESCRIPTION
In a recent optimization (#17) optimized the value pointers used by the runtime for scalar types. This avoids additional memory allocations. Experiments based on the Savina Benchmarks showed that there is potential to also reduce overhead for small structs and similar types. This PR applies the same optimization as in #17 to a wider range of types. Namely all that are trivially copyable and smaller smaller than 65 bytes. This threshold is arbitrarily chosen and we need to do more experimentation to select a good value.