### PR TITLE
Avoid locking when scheduling actions

### DIFF
--- a/include/reactor-cpp/impl/action_impl.hh
+++ b/include/reactor-cpp/impl/action_impl.hh
@@ -11,38 +11,50 @@
 
 #include "../assert.hh"
 #include "../environment.hh"
+#include <iterator>
+#include <mutex>
 
 namespace reactor {
 
 template <class T> template <class Dur> void Action<T>::schedule(const ImmutableValuePtr<T>& value_ptr, Dur delay) {
-  Duration time_delay = std::chrono::duration_cast<Duration>(delay); // NOLINT
+  Duration time_delay = std::chrono::duration_cast<Duration>(delay);
   reactor::validate(time_delay >= Duration::zero(), "Schedule cannot be called with a negative delay!");
   reactor::validate(value_ptr != nullptr, "Actions may not be scheduled with a nullptr value!");
-  auto* scheduler = environment()->scheduler();                                  // NOLINT
-  auto setup = [value_ptr, this]() { this->value_ptr_ = std::move(value_ptr); }; // NOLINT
+  auto* scheduler = environment()->scheduler();
   if (is_logical()) {
     time_delay += this->min_delay();
     auto tag = Tag::from_logical_time(scheduler->logical_time()).delay(time_delay); // NOLINT
-    scheduler->schedule_sync(tag, this, setup);
+    events_[tag] = value_ptr;
+    scheduler->schedule_sync(tag, this);
   } else {
-    auto tag = Tag::from_physical_time(get_physical_time() + time_delay); // NOLINT
-    scheduler->schedule_async(tag, this, setup);
+    auto tag = Tag::from_physical_time(get_physical_time() + time_delay);
+    {
+      std::lock_guard<std::mutex> lg(mutex_events_);
+      events_[tag] = value_ptr;
+    }
+    scheduler->schedule_async(tag, this);
   }
 }
 
 template <class Dur> void Action<void>::schedule(Dur delay) {
-  auto time_delay = std::chrono::duration_cast<Duration>(delay); // NOLINT
+  auto time_delay = std::chrono::duration_cast<Duration>(delay);
   reactor::validate(time_delay >= Duration::zero(), "Schedule cannot be called with a negative delay!");
-  auto* scheduler = environment()->scheduler();     // NOLINT
-  auto setup = [this]() { this->present_ = true; }; // NOLINT
+  auto* scheduler = environment()->scheduler();
   if (is_logical()) {
     time_delay += this->min_delay();
-    auto tag = Tag::from_logical_time(scheduler->logical_time()).delay(time_delay); // NOLINT
-    scheduler->schedule_sync(tag, this, setup);
+    auto tag = Tag::from_logical_time(scheduler->logical_time()).delay(time_delay);
+    scheduler->schedule_sync(tag, this);
   } else {
     // physical action
-    auto tag = Tag::from_physical_time(get_physical_time() + time_delay); // NOLINT
-    scheduler->schedule_async(tag, this, setup);
+    auto tag = Tag::from_physical_time(get_physical_time() + time_delay);
+    scheduler->schedule_async(tag, this);
+  }
+}
+
+template <class T> void Action<T>::setup() noexcept {
+  const auto& node = events_.extract(events_.begin());
+  if (!node.empty()) {
+    value_ptr_ = std::move(node.mapped());
   }
 }
 

--- a/include/reactor-cpp/impl/action_impl.hh
+++ b/include/reactor-cpp/impl/action_impl.hh
@@ -52,8 +52,9 @@ template <class Dur> void Action<void>::schedule(Dur delay) {
 }
 
 template <class T> void Action<T>::setup() noexcept {
-  const auto& node = events_.extract(events_.begin());
-  if (!node.empty()) {
+  if (value_ptr_ == nullptr) {
+    const auto& node = events_.extract(events_.begin());
+    reactor_assert(!node.empty());
     value_ptr_ = std::move(node.mapped());
   }
 }

--- a/include/reactor-cpp/safe_vector.hh
+++ b/include/reactor-cpp/safe_vector.hh
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <cstddef>
 #include <mutex>
+#include <shared_mutex>
 #include <vector>
 
 namespace reactor {
@@ -20,30 +21,35 @@ template <class T> class SafeVector {
 private:
   static constexpr std::size_t size_increment_{100};
   std::atomic<std::size_t> write_pos_{0};
-  std::atomic<std::size_t> vector_size_{size_increment_};
+  std::size_t vector_size_{size_increment_};
   std::vector<T> vector_{size_increment_};
-  std::mutex mutex_;
+  std::shared_mutex mutex_;
 
 public:
   void push_back(const T& value) {
-    auto pos = write_pos_.fetch_add(1, std::memory_order_acq_rel);
-    auto size = vector_size_.load(std::memory_order_acquire);
+    auto pos = write_pos_.fetch_add(1, std::memory_order_release);
 
-    if (pos < size) {
-      vector_[pos] = value;
-    } else {
-      std::lock_guard<std::mutex> lock(mutex_);
-      while (pos >= vector_size_) {
-        vector_size_.fetch_add(size_increment_, std::memory_order_release);
-        vector_.resize(vector_size_.load(std::memory_order_relaxed));
+    {
+      std::shared_lock<std::shared_mutex> shared_lock(mutex_);
+      if (pos < vector_size_) {
+        vector_[pos] = value;
+      } else {
+        shared_lock.unlock();
+        {
+          std::unique_lock<std::shared_mutex> unique_lock(mutex_);
+          while (pos >= vector_size_) {
+            vector_size_ += size_increment_;
+            vector_.resize(vector_size_);
+          }
+          vector_[pos] = value;
+        }
       }
-      vector_[pos] = value;
     }
   }
 
   // careful! Using the iterators is only safe if no more elements are added to the vector!
-  auto begin() -> auto { return vector_.begin(); }
-  auto end() -> auto { return vector_.begin() + write_pos_.load(std::memory_order_acquire); }
+  auto begin() -> auto{ return vector_.begin(); }
+  auto end() -> auto{ return vector_.begin() + write_pos_.load(std::memory_order_acquire); }
 
   auto size() -> std::size_t { return write_pos_.load(std::memory_order_acquire); }
   auto empty() -> bool { return size() == 0; }

--- a/include/reactor-cpp/safe_vector.hh
+++ b/include/reactor-cpp/safe_vector.hh
@@ -42,8 +42,8 @@ public:
   }
 
   // careful! Using the iterators is only safe if no more elements are added to the vector!
-  auto begin() -> auto{ return vector_.begin(); }
-  auto end() -> auto{ return vector_.begin() + write_pos_.load(std::memory_order_acquire); }
+  auto begin() -> auto { return vector_.begin(); }
+  auto end() -> auto { return vector_.begin() + write_pos_.load(std::memory_order_acquire); }
 
   auto size() -> std::size_t { return write_pos_.load(std::memory_order_acquire); }
   auto empty() -> bool { return size() == 0; }

--- a/include/reactor-cpp/safe_vector.hh
+++ b/include/reactor-cpp/safe_vector.hh
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <deque>
 #include <mutex>
-#include <shared_mutex>
 
 namespace reactor {
 
@@ -21,33 +20,29 @@ template <class T> class SafeVector {
 private:
   static constexpr std::size_t size_increment_{100};
   std::atomic<std::size_t> write_pos_{0};
-  std::size_t deque_size_{size_increment_};
+  std::atomic<std::size_t> deque_size_{size_increment_};
   std::deque<T> deque_{size_increment_};
-  std::shared_mutex mutex_;
+  std::mutex mutex_;
 
 public:
   void push_back(const T& value) {
-    auto pos = write_pos_.fetch_add(1, std::memory_order_release);
-    {
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (pos < deque_size_) {
-        deque_[pos] = value;
-      } else {
-        lock.unlock();
-        {
-          std::unique_lock<std::shared_mutex> unique_lock(mutex_);
-          while (pos < deque_size_) {
-            deque_size_ += size_increment_;
-            deque_.resize(deque_size_);
-          }
-          deque_[pos] = value;
-        }
+    auto pos = write_pos_.fetch_add(1, std::memory_order_relaxed);
+    auto size = deque_size_.load(std::memory_order_acquire);
+
+    if (pos < size) {
+      deque_[pos] = value;
+    } else {
+      std::lock_guard<std::mutex> lock(mutex_);
+      while (pos < deque_size_) {
+        deque_.resize(deque_size_);
+        deque_size_.fetch_add(size_increment_, std::memory_order_release);
       }
+      deque_[pos] = value;
     }
   }
 
   // careful! Using the iterators is only safe if no more elements are added to the vector!
-  auto begin() -> auto { return deque_.begin(); }
+  auto begin() -> auto{ return deque_.begin(); }
   auto end() -> auto{ return deque_.begin() + write_pos_.load(std::memory_order_acquire); }
 
   auto size() -> std::size_t { return write_pos_.load(std::memory_order_acquire); }

--- a/include/reactor-cpp/safe_vector.hh
+++ b/include/reactor-cpp/safe_vector.hh
@@ -34,8 +34,8 @@ public:
     } else {
       std::lock_guard<std::mutex> lock(mutex_);
       while (pos >= vector_size_) {
-        vector_.resize(vector_size_);
         vector_size_.fetch_add(size_increment_, std::memory_order_release);
+        vector_.resize(vector_size_.load(std::memory_order_relaxed));
       }
       vector_[pos] = value;
     }

--- a/include/reactor-cpp/safe_vector.hh
+++ b/include/reactor-cpp/safe_vector.hh
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 TU Dresden
+ * All rights reserved.
+ *
+ * Authors:
+ *   Christian Menard
+ */
+
+#ifndef REACTOR_CPP_SAFE_VECTOR_HH
+#define REACTOR_CPP_SAFE_VECTOR_HH
+
+#include <atomic>
+#include <cstddef>
+#include <deque>
+#include <mutex>
+#include <shared_mutex>
+
+namespace reactor {
+
+template <class T> class SafeVector {
+private:
+  static constexpr std::size_t size_increment_{100};
+  std::atomic<std::size_t> write_pos_{0};
+  std::size_t deque_size_{size_increment_};
+  std::deque<T> deque_{size_increment_};
+  std::shared_mutex mutex_;
+
+public:
+  void push_back(const T& value) {
+    auto pos = write_pos_.fetch_add(1, std::memory_order_release);
+    {
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (pos < deque_size_) {
+        deque_[pos] = value;
+      } else {
+        lock.unlock();
+        {
+          std::unique_lock<std::shared_mutex> unique_lock(mutex_);
+          while (pos < deque_size_) {
+            deque_size_ += size_increment_;
+            deque_.resize(deque_size_);
+          }
+          deque_[pos] = value;
+        }
+      }
+    }
+  }
+
+  // careful! Using the iterators is only safe if no more elements are added to the vector!
+  auto begin() -> auto { return deque_.begin(); }
+  auto end() -> auto{ return deque_.begin() + write_pos_.load(std::memory_order_acquire); }
+
+  auto size() -> std::size_t { return write_pos_.load(std::memory_order_acquire); }
+  auto empty() -> bool { return size() == 0; }
+};
+
+} // namespace reactor
+
+#endif // REACTOR_CPP_SAFE_VECTOR_HH

--- a/include/reactor-cpp/safe_vector.hh
+++ b/include/reactor-cpp/safe_vector.hh
@@ -33,7 +33,7 @@ public:
       deque_[pos] = value;
     } else {
       std::lock_guard<std::mutex> lock(mutex_);
-      while (pos < deque_size_) {
+      while (pos >= deque_size_) {
         deque_.resize(deque_size_);
         deque_size_.fetch_add(size_increment_, std::memory_order_release);
       }

--- a/include/reactor-cpp/safe_vector.hh
+++ b/include/reactor-cpp/safe_vector.hh
@@ -48,8 +48,8 @@ public:
   }
 
   // careful! Using the iterators is only safe if no more elements are added to the vector!
-  auto begin() -> auto{ return vector_.begin(); }
-  auto end() -> auto{ return vector_.begin() + write_pos_.load(std::memory_order_acquire); }
+  auto begin() -> auto { return vector_.begin(); }
+  auto end() -> auto { return vector_.begin() + write_pos_.load(std::memory_order_acquire); }
 
   auto size() -> std::size_t { return write_pos_.load(std::memory_order_acquire); }
   auto empty() -> bool { return size() == 0; }

--- a/include/reactor-cpp/safe_vector.hh
+++ b/include/reactor-cpp/safe_vector.hh
@@ -11,8 +11,8 @@
 
 #include <atomic>
 #include <cstddef>
-#include <deque>
 #include <mutex>
+#include <vector>
 
 namespace reactor {
 
@@ -20,33 +20,35 @@ template <class T> class SafeVector {
 private:
   static constexpr std::size_t size_increment_{100};
   std::atomic<std::size_t> write_pos_{0};
-  std::atomic<std::size_t> deque_size_{size_increment_};
-  std::deque<T> deque_{size_increment_};
+  std::atomic<std::size_t> vector_size_{size_increment_};
+  std::vector<T> vector_{size_increment_};
   std::mutex mutex_;
 
 public:
   void push_back(const T& value) {
-    auto pos = write_pos_.fetch_add(1, std::memory_order_relaxed);
-    auto size = deque_size_.load(std::memory_order_acquire);
+    auto pos = write_pos_.fetch_add(1, std::memory_order_acq_rel);
+    auto size = vector_size_.load(std::memory_order_acquire);
 
     if (pos < size) {
-      deque_[pos] = value;
+      vector_[pos] = value;
     } else {
       std::lock_guard<std::mutex> lock(mutex_);
-      while (pos >= deque_size_) {
-        deque_.resize(deque_size_);
-        deque_size_.fetch_add(size_increment_, std::memory_order_release);
+      while (pos >= vector_size_) {
+        vector_.resize(vector_size_);
+        vector_size_.fetch_add(size_increment_, std::memory_order_release);
       }
-      deque_[pos] = value;
+      vector_[pos] = value;
     }
   }
 
   // careful! Using the iterators is only safe if no more elements are added to the vector!
-  auto begin() -> auto{ return deque_.begin(); }
-  auto end() -> auto{ return deque_.begin() + write_pos_.load(std::memory_order_acquire); }
+  auto begin() -> auto{ return vector_.begin(); }
+  auto end() -> auto{ return vector_.begin() + write_pos_.load(std::memory_order_acquire); }
 
   auto size() -> std::size_t { return write_pos_.load(std::memory_order_acquire); }
   auto empty() -> bool { return size() == 0; }
+
+  void clear() { write_pos_.store(0, std::memory_order_release); }
 };
 
 } // namespace reactor

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -105,6 +105,10 @@ private:
   std::shared_mutex mutex_event_queue_;
   std::map<Tag, ActionListPtr> event_queue_;
 
+  std::vector<ActionListPtr> action_list_pool_;
+  static constexpr std::size_t action_list_pool_increment_{10};
+  void fill_action_list_pool();
+
   std::vector<std::vector<BasePort*>> set_ports_;
   std::vector<std::vector<Reaction*>> triggered_reactions_;
 

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -15,11 +15,13 @@
 #include <map>
 #include <mutex>
 #include <set>
+#include <shared_mutex>
 #include <thread>
 #include <vector>
 
 #include "fwd.hh"
 #include "logical_time.hh"
+#include "safe_vector.hh"
 #include "semaphore.hh"
 
 namespace reactor {
@@ -85,6 +87,9 @@ public:
   void fill_up(std::vector<Reaction*>& ready_reactions);
 };
 
+using ActionList = SafeVector<BaseAction*>;
+using ActionListPtr = std::unique_ptr<ActionList>;
+
 class Scheduler { // NOLINT
 private:
   const bool using_workers_;
@@ -97,8 +102,8 @@ private:
   std::unique_lock<std::mutex> scheduling_lock_{scheduling_mutex_, std::defer_lock};
   std::condition_variable cv_schedule_;
 
-  std::mutex lock_event_queue_;
-  std::map<Tag, std::vector<BaseAction*>> event_queue_;
+  std::shared_mutex mutex_event_queue_;
+  std::map<Tag, ActionListPtr> event_queue_;
 
   std::vector<std::vector<BasePort*>> set_ports_;
   std::vector<std::vector<Reaction*>> triggered_reactions_;

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -85,8 +85,6 @@ public:
   void fill_up(std::vector<Reaction*>& ready_reactions);
 };
 
-using EventMap = std::map<BaseAction*, std::function<void(void)>>;
-
 class Scheduler { // NOLINT
 private:
   const bool using_workers_;
@@ -100,7 +98,7 @@ private:
   std::condition_variable cv_schedule_;
 
   std::mutex lock_event_queue_;
-  std::map<Tag, EventMap> event_queue_;
+  std::map<Tag, std::vector<BaseAction*>> event_queue_;
 
   std::vector<std::vector<BasePort*>> set_ports_;
   std::vector<std::vector<Reaction*>> triggered_reactions_;
@@ -124,8 +122,8 @@ public:
   explicit Scheduler(Environment* env);
   ~Scheduler();
 
-  void schedule_sync(const Tag& tag, BaseAction* action, std::function<void(void)> pre_handler);
-  void schedule_async(const Tag& tag, BaseAction* action, std::function<void(void)> pre_handler);
+  void schedule_sync(const Tag& tag, BaseAction* action);
+  void schedule_async(const Tag& tag, BaseAction* action);
 
   void inline lock() noexcept { scheduling_lock_.lock(); }
   void inline unlock() noexcept { scheduling_lock_.unlock(); }

--- a/include/reactor-cpp/value_ptr.hh
+++ b/include/reactor-cpp/value_ptr.hh
@@ -75,7 +75,6 @@ template <class T, class... Args> auto make_mutable_value(Args&&... args) -> Mut
   }
 }
 
-
 namespace detail {
 
 /**
@@ -510,7 +509,6 @@ public:
   friend auto reactor::make_immutable_value(Args&&... args) -> reactor::ImmutableValuePtr<U>;
 };
 
-
 // Comparison operators
 
 template <class T, class U, bool scalar>
@@ -529,16 +527,20 @@ template <class T, class U, bool scalar>
 auto operator==(const MutableValuePtr<T, scalar>& ptr1, const ImmutableValuePtr<U, scalar>& ptr2) noexcept -> bool {
   return ptr1.get() == ptr2.get();
 }
-template <class T, bool scalar> auto operator==(const MutableValuePtr<T, scalar>& ptr1, std::nullptr_t) noexcept -> bool {
+template <class T, bool scalar>
+auto operator==(const MutableValuePtr<T, scalar>& ptr1, std::nullptr_t) noexcept -> bool {
   return ptr1.get() == nullptr;
 }
-template <class T, bool scalar> auto operator==(std::nullptr_t, const MutableValuePtr<T, scalar>& ptr2) noexcept -> bool {
+template <class T, bool scalar>
+auto operator==(std::nullptr_t, const MutableValuePtr<T, scalar>& ptr2) noexcept -> bool {
   return ptr2.get() == nullptr;
 }
-template <class T, bool scalar> auto operator==(const ImmutableValuePtr<T, scalar>& ptr1, std::nullptr_t) noexcept -> bool {
+template <class T, bool scalar>
+auto operator==(const ImmutableValuePtr<T, scalar>& ptr1, std::nullptr_t) noexcept -> bool {
   return ptr1.get() == nullptr;
 }
-template <class T, bool scalar> auto operator==(std::nullptr_t, const ImmutableValuePtr<T, scalar>& ptr1) noexcept -> bool {
+template <class T, bool scalar>
+auto operator==(std::nullptr_t, const ImmutableValuePtr<T, scalar>& ptr1) noexcept -> bool {
   return ptr1.get() == nullptr;
 }
 
@@ -551,10 +553,12 @@ template <class T, class U, bool scalar>
 auto operator!=(const ImmutableValuePtr<T, scalar>& ptr1, const ImmutableValuePtr<U, scalar>& ptr2) -> bool {
   return ptr1.get() != ptr2.get();
 }
-template <class T, class U, bool scalar> auto operator!=(const ImmutableValuePtr<T, scalar>& ptr1, const MutableValuePtr<U, scalar>& ptr2) -> bool {
+template <class T, class U, bool scalar>
+auto operator!=(const ImmutableValuePtr<T, scalar>& ptr1, const MutableValuePtr<U, scalar>& ptr2) -> bool {
   return ptr1.get() != ptr2.get();
 }
-template <class T, class U, bool scalar> auto operator!=(const MutableValuePtr<T, scalar>& ptr1, const ImmutableValuePtr<U, scalar>& ptr2) -> bool {
+template <class T, class U, bool scalar>
+auto operator!=(const MutableValuePtr<T, scalar>& ptr1, const ImmutableValuePtr<U, scalar>& ptr2) -> bool {
   return ptr1.get() != ptr2.get();
 }
 template <class T, bool scalar> auto operator!=(const MutableValuePtr<T, scalar>& ptr1, std::nullptr_t) -> bool {
@@ -569,7 +573,6 @@ template <class T, bool scalar> auto operator!=(const ImmutableValuePtr<T, scala
 template <class T, bool scalar> auto operator!=(std::nullptr_t, const ImmutableValuePtr<T, scalar>& ptr1) -> bool {
   return ptr1.get() != nullptr;
 }
-
 
 } // namespace detail
 

--- a/lib/action.cc
+++ b/lib/action.cc
@@ -37,24 +37,24 @@ void BaseAction::register_scheduler(Reaction* reaction) {
 void Timer::startup() {
   Tag tag_zero = Tag::from_physical_time(environment()->start_time());
   if (offset_ != Duration::zero()) {
-    environment()->scheduler()->schedule_sync(tag_zero.delay(offset_), this, nullptr);
+    environment()->scheduler()->schedule_sync(tag_zero.delay(offset_), this);
   } else {
-    environment()->scheduler()->schedule_sync(tag_zero, this, nullptr);
+    environment()->scheduler()->schedule_sync(tag_zero, this);
   }
 }
 
-void Timer::cleanup() {
+void Timer::cleanup() noexcept {
   // schedule the timer again
   if (period_ != Duration::zero()) {
     Tag now = Tag::from_logical_time(environment()->logical_time());
     Tag next = now.delay(period_);
-    environment()->scheduler()->schedule_sync(next, this, nullptr);
+    environment()->scheduler()->schedule_sync(next, this);
   }
 }
 
 void ShutdownAction::shutdown() {
   Tag tag = Tag::from_logical_time(environment()->logical_time()).delay();
-  environment()->scheduler()->schedule_sync(tag, this, nullptr);
+  environment()->scheduler()->schedule_sync(tag, this);
 }
 
 } // namespace reactor

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -223,13 +223,13 @@ void Scheduler::start() {
 }
 
 void Scheduler::next() { // NOLINT
-  static EventMap events{};
+  static std::vector<BaseAction*> actions{};
 
   // clean up before scheduling any new events
-  if (!events.empty()) {
+  if (!actions.empty()) {
     // cleanup all triggered actions
-    for (auto& vec_ports : events) {
-      vec_ports.first->cleanup();
+    for (auto* action : actions) {
+      action->cleanup();
     }
     // cleanup all set ports
     for (auto& vec_ports : set_ports_) {
@@ -238,7 +238,7 @@ void Scheduler::next() { // NOLINT
       }
       vec_ports.clear();
     }
-    events.clear();
+    actions.clear();
   }
 
   {
@@ -255,7 +255,7 @@ void Scheduler::next() { // NOLINT
       }
     }
 
-    while (events.empty()) {
+    while (actions.empty()) {
       if (stop_) {
         continue_execution_ = false;
         log::Debug() << "Shutting down the scheduler";
@@ -263,7 +263,7 @@ void Scheduler::next() { // NOLINT
         if (t_next == event_queue_.begin()->first) {
           log::Debug() << "Schedule the last round of reactions including all "
                           "termination reactions";
-          events = std::move(event_queue_.begin()->second);
+          actions = std::move(event_queue_.begin()->second);
           event_queue_.erase(event_queue_.begin());
           log::Debug() << "advance logical time to tag [" << t_next.time_point() << ", " << t_next.micro_step() << "]";
           logical_time_.advance_to(t_next);
@@ -303,7 +303,7 @@ void Scheduler::next() { // NOLINT
 
         // retrieve all events with tag equal to current logical time from the
         // queue
-        events = std::move(event_queue_.begin()->second);
+        actions = std::move(event_queue_.begin()->second);
         event_queue_.erase(event_queue_.begin());
 
         // advance logical time
@@ -315,17 +315,14 @@ void Scheduler::next() { // NOLINT
 
   // execute all setup functions; this sets the values of the corresponding
   // actions
-  for (auto& vec_reactor : events) {
-    auto& setup = vec_reactor.second;
-    if (setup != nullptr) {
-      setup();
-    }
+  for (auto* action : actions) {
+    action->setup();
   }
 
-  log::Debug() << "events: " << events.size();
-  for (auto& vec_reactor : events) {
-    log::Debug() << "Action " << vec_reactor.first->fqn();
-    for (auto* reaction : vec_reactor.first->triggers()) {
+  log::Debug() << "events: " << actions.size();
+  for (const auto* action : actions) {
+    log::Debug() << "Action " << action->fqn();
+    for (auto* reaction : action->triggers()) {
       // There is no need to acquire the mutex. At this point the scheduler
       // should be the only thread accessing the reaction queue as none of the
       // workers_ are running
@@ -342,7 +339,7 @@ Scheduler::Scheduler(Environment* env)
 
 Scheduler::~Scheduler() = default;
 
-void Scheduler::schedule_sync(const Tag& tag, BaseAction* action, std::function<void(void)> pre_handler) {
+void Scheduler::schedule_sync(const Tag& tag, BaseAction* action) {
   reactor_assert(logical_time_ < tag);
   // TODO verify that the action is indeed allowed to be scheduled by the
   // current reaction
@@ -352,20 +349,20 @@ void Scheduler::schedule_sync(const Tag& tag, BaseAction* action, std::function<
     auto unique_lock =
         using_workers_ ? std::unique_lock<std::mutex>(lock_event_queue_) : std::unique_lock<std::mutex>();
 
-    tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag); // NOLINT
+    tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag);
 
-    // create a new event map or retrieve the existing one
-    auto emplace_result = event_queue_.try_emplace(tag, EventMap());
-    auto& event_map = emplace_result.first->second;
+    // create a new action list or retrieve the existing one
+    auto emplace_result = event_queue_.try_emplace(tag, std::vector<BaseAction*>());
+    auto& action_list = emplace_result.first->second;
 
-    // insert the new event
-    event_map[action] = std::move(pre_handler);
+    // insert the new action
+    action_list.emplace_back(action);
   }
 }
 
-void Scheduler::schedule_async(const Tag& tag, BaseAction* action, std::function<void(void)> pre_handler) {
+void Scheduler::schedule_async(const Tag& tag, BaseAction* action) {
   std::lock_guard<std::mutex> lock_guard(scheduling_mutex_);
-  schedule_sync(tag, action, std::move(pre_handler));
+  schedule_sync(tag, action);
   cv_schedule_.notify_one();
 }
 


### PR DESCRIPTION
This patch changes the mechanism used for scheduling actions. Instead of managing everything centrally, each action is now responsible for keeping track of its scheduled values. This considerably reduces the work that needs to be done while holding a lock. This patch further redesigns the event queue, such that in most cases scheduling can be done without locking.