### PR TITLE
Fix race condtions related to the scheduling of physical actions

### DIFF
--- a/include/reactor-cpp/impl/action_impl.hh
+++ b/include/reactor-cpp/impl/action_impl.hh
@@ -23,16 +23,15 @@ template <class T> template <class Dur> void Action<T>::schedule(const Immutable
   auto* scheduler = environment()->scheduler();
   if (is_logical()) {
     time_delay += this->min_delay();
-    auto tag = Tag::from_logical_time(scheduler->logical_time()).delay(time_delay); // NOLINT
+    auto tag = Tag::from_logical_time(scheduler->logical_time()).delay(time_delay);
     events_[tag] = value_ptr;
-    scheduler->schedule_sync(tag, this);
+    scheduler->schedule_sync(this, tag);
   } else {
-    auto tag = Tag::from_physical_time(get_physical_time() + time_delay);
+    auto tag = scheduler->schedule_async(this, time_delay);
     {
       std::lock_guard<std::mutex> lock(mutex_events_);
       events_[tag] = value_ptr;
     }
-    scheduler->schedule_async(tag, this);
   }
 }
 
@@ -43,11 +42,10 @@ template <class Dur> void Action<void>::schedule(Dur delay) {
   if (is_logical()) {
     time_delay += this->min_delay();
     auto tag = Tag::from_logical_time(scheduler->logical_time()).delay(time_delay);
-    scheduler->schedule_sync(tag, this);
+    scheduler->schedule_sync(this, tag);
   } else {
     // physical action
-    auto tag = Tag::from_physical_time(get_physical_time() + time_delay);
-    scheduler->schedule_async(tag, this);
+    scheduler->schedule_async(this, time_delay);
   }
 }
 

--- a/include/reactor-cpp/logical_time.hh
+++ b/include/reactor-cpp/logical_time.hh
@@ -15,21 +15,22 @@ namespace reactor {
 using mstep_t = unsigned long; // at least 32 bit
 class LogicalTime;
 
-class Tag { // NOLINT
+class Tag {
 private:
-  const TimePoint time_point_{};
-  const mstep_t micro_step_;
+  TimePoint time_point_{};
+  mstep_t micro_step_{0};
 
   Tag(const TimePoint& time_point, const mstep_t& micro_step)
       : time_point_{time_point}
       , micro_step_{micro_step} {}
 
 public:
-  // no default constructor, not assignable, but movable and copyable
-  Tag() = delete;
-  auto operator=(const Tag&) -> Tag& = delete;
+  Tag() = default;
   Tag(Tag&&) = default;
   Tag(const Tag&) = default;
+  auto operator=(const Tag&) -> Tag& = default;
+  auto operator=(Tag&&) -> Tag& = default;
+  ~Tag() = default;
 
   [[nodiscard]] auto time_point() const noexcept -> const TimePoint& { return time_point_; }
   [[nodiscard]] auto micro_step() const noexcept -> const mstep_t& { return micro_step_; }

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -134,7 +134,7 @@ public:
   void schedule_sync(BaseAction* action, const Tag& tag);
   auto schedule_async(BaseAction* action, const Duration& delay) -> Tag;
 
-  auto inline lock() noexcept -> auto{ return std::unique_lock<std::mutex>(scheduling_mutex_); }
+  auto inline lock() noexcept -> auto { return std::unique_lock<std::mutex>(scheduling_mutex_); }
 
   void set_port(BasePort* port);
 

--- a/lib/action.cc
+++ b/lib/action.cc
@@ -37,9 +37,9 @@ void BaseAction::register_scheduler(Reaction* reaction) {
 void Timer::startup() {
   Tag tag_zero = Tag::from_physical_time(environment()->start_time());
   if (offset_ != Duration::zero()) {
-    environment()->scheduler()->schedule_sync(tag_zero.delay(offset_), this);
+    environment()->scheduler()->schedule_sync(this, tag_zero.delay(offset_));
   } else {
-    environment()->scheduler()->schedule_sync(tag_zero, this);
+    environment()->scheduler()->schedule_sync(this, tag_zero);
   }
 }
 
@@ -48,13 +48,13 @@ void Timer::cleanup() noexcept {
   if (period_ != Duration::zero()) {
     Tag now = Tag::from_logical_time(environment()->logical_time());
     Tag next = now.delay(period_);
-    environment()->scheduler()->schedule_sync(next, this);
+    environment()->scheduler()->schedule_sync(this, next);
   }
 }
 
 void ShutdownAction::shutdown() {
   Tag tag = Tag::from_logical_time(environment()->logical_time()).delay();
-  environment()->scheduler()->schedule_sync(tag, this);
+  environment()->scheduler()->schedule_sync(this, tag);
 }
 
 } // namespace reactor

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -101,9 +101,8 @@ void Environment::sync_shutdown() {
 }
 
 void Environment::async_shutdown() {
-  scheduler_.lock();
+  auto lock_guard = scheduler_.lock();
   sync_shutdown();
-  scheduler_.unlock();
 }
 
 auto dot_name([[maybe_unused]] ReactorElement* reactor_element) -> std::string {

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -352,10 +352,8 @@ void Scheduler::fill_action_list_pool() {
   }
 }
 
-void Scheduler::schedule_sync(const Tag& tag, BaseAction* action) {
+void Scheduler::schedule_sync(BaseAction* action, const Tag& tag) {
   reactor_assert(logical_time_ < tag);
-  // TODO verify that the action is indeed allowed to be scheduled by the
-  // current reaction
   log::Debug() << "Schedule action " << action->fqn() << (action->is_logical() ? " synchronously " : " asynchronously ")
                << " with tag [" << tag.time_point() << ", " << tag.micro_step() << "]";
   tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag);
@@ -392,10 +390,15 @@ void Scheduler::schedule_sync(const Tag& tag, BaseAction* action) {
   }
 }
 
-void Scheduler::schedule_async(const Tag& tag, BaseAction* action) {
-  std::lock_guard<std::mutex> lock_guard(scheduling_mutex_);
-  schedule_sync(tag, action);
+auto Scheduler::schedule_async(BaseAction* action, const Duration& delay) -> Tag {
+  Tag tag;
+  {
+    std::lock_guard<std::mutex> lock_guard(scheduling_mutex_);
+    tag = Tag::from_physical_time(get_physical_time() + delay);
+    schedule_sync(action, tag);
+  }
   cv_schedule_.notify_one();
+  return tag;
 }
 
 void Scheduler::set_port(BasePort* port) {

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -304,6 +304,7 @@ void Scheduler::next() { // NOLINT
             }
             // update physical time and continue otherwise
             physical_time = t_next.time_point();
+            reactor_assert(t_next == event_queue_.begin()->first);
           }
         }
 


### PR DESCRIPTION
This change fixes to race conditions

1. Before this change, it could happen that a physical action determines its next tag, but then the scheduler already advances beyond this tag before the new event is inserted in the event queue. In other words, determining the tag and inserting the event at this tag was not an atomic operation. This change includes the determining of the tag in `schedule_async` while the lock is held and hence makes scheduling physical actions an atomic operation.
2. There was a race condition on the internal event list kept by an action (`events_`) between scheduling the physical action and setting it up from the scheduler. This was fixed by acquiring the mutex also in `setup()`.