### PR TITLE
Enable multiple environments and shcedulers to run at the same time

### DIFF
--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "reactor-cpp/logging.hh"
+#include "reactor-cpp/time.hh"
 #include "reactor.hh"
 #include "scheduler.hh"
 
@@ -55,6 +56,8 @@ private:
 
   void build_dependency_graph(Reactor* reactor);
   void calculate_indexes();
+
+  auto startup(const TimePoint& start_time) -> std::thread;
 
 public:
   explicit Environment(unsigned int num_workers, bool run_forever = default_run_forever,

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -38,6 +38,13 @@ private:
   std::set<Reaction*> reactions_{};
   std::vector<Dependency> dependencies_{};
 
+  /// The environment containing this environment. nullptr if this is the top environment
+  Environment* containing_environment_{nullptr};
+  /// Set of all environments contained by this environment
+  std::set<Environment*> contained_environments_{};
+  /// Pointer to the top level environment
+  Environment* top_environment_{nullptr};
+
   Scheduler scheduler_;
   Phase phase_{Phase::Construction};
   TimePoint start_time_{};
@@ -47,11 +54,8 @@ private:
 
 public:
   explicit Environment(unsigned int num_workers, bool run_forever = default_run_forever,
-                       bool fast_fwd_execution = default_fast_fwd_execution)
-      : num_workers_(num_workers)
-      , run_forever_(run_forever)
-      , fast_fwd_execution_(fast_fwd_execution)
-      , scheduler_(this) {}
+                       bool fast_fwd_execution = default_fast_fwd_execution);
+  explicit Environment(Environment* containing_environment);
 
   void register_reactor(Reactor* reactor);
   void assemble();

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -59,7 +59,9 @@ private:
 public:
   explicit Environment(unsigned int num_workers, bool run_forever = default_run_forever,
                        bool fast_fwd_execution = default_fast_fwd_execution);
-  explicit Environment(std::string name, Environment* containing_environment);
+  explicit Environment(const std::string& name, Environment* containing_environment);
+
+  auto name() -> const std::string& { return name_; }
 
   void register_reactor(Reactor* reactor);
   void assemble();

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "reactor-cpp/logging.hh"
 #include "reactor.hh"
 #include "scheduler.hh"
 
@@ -29,6 +30,9 @@ public:
 
 private:
   using Dependency = std::pair<Reaction*, Reaction*>;
+
+  const std::string name_{};
+  const log::NamedLogger log_;
   const unsigned int num_workers_{default_number_worker};
   unsigned int max_reaction_index_{default_max_reaction_index};
   const bool run_forever_{default_run_forever};
@@ -55,7 +59,7 @@ private:
 public:
   explicit Environment(unsigned int num_workers, bool run_forever = default_run_forever,
                        bool fast_fwd_execution = default_fast_fwd_execution);
-  explicit Environment(Environment* containing_environment);
+  explicit Environment(std::string name, Environment* containing_environment);
 
   void register_reactor(Reactor* reactor);
   void assemble();

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -111,6 +111,8 @@ private:
 
   std::shared_mutex mutex_event_queue_;
   std::map<Tag, ActionListPtr> event_queue_;
+  /// stores the actions triggered at the current tag
+  ActionListPtr triggered_actions_{nullptr};
 
   std::vector<ActionListPtr> action_list_pool_;
   static constexpr std::size_t action_list_pool_increment_{10};

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -21,6 +21,7 @@
 
 #include "fwd.hh"
 #include "logical_time.hh"
+#include "reactor-cpp/logging.hh"
 #include "reactor-cpp/time.hh"
 #include "safe_vector.hh"
 #include "semaphore.hh"
@@ -32,10 +33,11 @@ class Scheduler;
 class Worker;
 
 class Worker { // NOLINT
-public:
+private:
   Scheduler& scheduler_;
   const unsigned int identity_{0};
   std::thread thread_{};
+  log::NamedLogger log_;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static thread_local const Worker* current_worker;
@@ -43,9 +45,11 @@ public:
   void work() const;
   void execute_reaction(Reaction* reaction) const;
 
-  Worker(Scheduler& scheduler, unsigned int identity)
+public:
+  Worker(Scheduler& scheduler, unsigned int identity, const std::string& name)
       : scheduler_{scheduler}
-      , identity_{identity} {}
+      , identity_{identity}
+      , log_(name) {}
   Worker(Worker&& worker); // NOLINT(performance-noexcept-move-constructor)
   Worker(const Worker& worker) = delete;
 
@@ -62,10 +66,12 @@ private:
   Semaphore sem_{0};
   std::ptrdiff_t waiting_workers_{0};
   const unsigned int num_workers_;
+  log::NamedLogger& log_;
 
 public:
-  explicit ReadyQueue(unsigned num_workers)
-      : num_workers_(num_workers) {}
+  explicit ReadyQueue(log::NamedLogger& log, unsigned num_workers)
+      : num_workers_(num_workers)
+      , log_(log) {}
 
   /**
    * Retrieve a ready reaction from the queue.
@@ -98,6 +104,7 @@ private:
 
   Environment* environment_;
   std::vector<Worker> workers_{};
+  log::NamedLogger log_;
 
   std::mutex scheduling_mutex_;
   std::condition_variable cv_schedule_;
@@ -134,7 +141,7 @@ public:
   void schedule_sync(BaseAction* action, const Tag& tag);
   auto schedule_async(BaseAction* action, const Duration& delay) -> Tag;
 
-  auto inline lock() noexcept -> auto { return std::unique_lock<std::mutex>(scheduling_mutex_); }
+  auto inline lock() noexcept -> auto{ return std::unique_lock<std::mutex>(scheduling_mutex_); }
 
   void set_port(BasePort* port);
 

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -101,6 +101,7 @@ class Scheduler { // NOLINT
 private:
   const bool using_workers_;
   LogicalTime logical_time_{};
+  TimePoint last_observed_physical_time_{TimePoint::min()};
 
   Environment* environment_;
   std::vector<Worker> workers_{};

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -20,6 +20,23 @@
 
 namespace reactor {
 
+Environment::Environment(unsigned int num_workers, bool run_forever, bool fast_fwd_execution)
+    : num_workers_(num_workers)
+    , run_forever_(run_forever)
+    , fast_fwd_execution_(fast_fwd_execution)
+    , top_environment_(this)
+    , scheduler_(this) {}
+
+Environment::Environment(Environment* containing_environment)
+    : num_workers_(containing_environment->num_workers_)
+    , run_forever_(containing_environment->run_forever_)
+    , fast_fwd_execution_(containing_environment->fast_fwd_execution_)
+    , containing_environment_(containing_environment)
+    , top_environment_(containing_environment_->top_environment_)
+    , scheduler_(this) {
+  reactor_assert(containing_environment->contained_environments_.insert(this).second);
+}
+
 void Environment::register_reactor(Reactor* reactor) {
   reactor_assert(reactor != nullptr);
   validate(this->phase() == Phase::Construction, "Reactors may only be registered during construction phase!");

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -30,8 +30,8 @@ Environment::Environment(unsigned int num_workers, bool run_forever, bool fast_f
     , top_environment_(this)
     , scheduler_(this) {}
 
-Environment::Environment(std::string name, Environment* containing_environment)
-    : name_(std::move(name))
+Environment::Environment(const std::string& name, Environment* containing_environment)
+    : name_(name)
     , log_("Environment " + name)
     , num_workers_(containing_environment->num_workers_)
     , run_forever_(containing_environment->run_forever_)

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -237,7 +237,7 @@ void Environment::calculate_indexes() {
 auto Environment::startup() -> std::thread {
   validate(this->phase() == Phase::Assembly, "startup() may only be called during assembly phase!");
 
-  log_.info() << "Starting the execution";
+  log_.debug() << "Starting the execution";
   phase_ = Phase::Startup;
 
   start_time_ = get_physical_time();

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -57,6 +57,7 @@ void recursive_assemble(Reactor* container) { // NOLINT
 }
 
 void Environment::assemble() {
+  log_.debug() << "Assemble";
   validate(this->phase() == Phase::Construction, "assemble() may only be called during construction phase!");
   phase_ = Phase::Assembly;
   for (auto* reactor : top_level_reactors_) {

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -114,7 +114,7 @@ void Environment::sync_shutdown() {
   validate(this->phase() == Phase::Execution, "sync_shutdown() may only be called during execution phase!");
   phase_ = Phase::Shutdown;
 
-  log::Info() << "Terminating the execution";
+  log::Debug() << "Terminating the execution";
 
   for (auto* reactor : top_level_reactors_) {
     reactor->shutdown();
@@ -239,7 +239,7 @@ auto Environment::startup() -> std::thread {
   }
   calculate_indexes();
 
-  log::Info() << "Starting the execution";
+  log::Debug() << "Starting the execution";
   phase_ = Phase::Startup;
 
   start_time_ = get_physical_time();

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -235,12 +235,18 @@ void Environment::calculate_indexes() {
 }
 
 auto Environment::startup() -> std::thread {
+  validate(this == top_environment_, "startup() may only be called on the top environment");
+  auto start_time = get_physical_time();
+  return startup(start_time);
+}
+
+auto Environment::startup(const TimePoint& start_time) -> std::thread {
   validate(this->phase() == Phase::Assembly, "startup() may only be called during assembly phase!");
 
   log_.debug() << "Starting the execution";
   phase_ = Phase::Startup;
 
-  start_time_ = get_physical_time();
+  start_time_ = start_time;
   // start up initialize all reactors
   for (auto* reactor : top_level_reactors_) {
     reactor->startup();
@@ -253,7 +259,7 @@ auto Environment::startup() -> std::thread {
     std::vector<std::thread> threads;
     // startup all contained environments recursively
     for (auto* env : contained_environments_) {
-      threads.emplace_back(env->startup());
+      threads.emplace_back(env->startup(start_time_));
     }
     // start the local scheduler and wait until it returns
     this->scheduler_.start();

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -237,12 +237,6 @@ void Environment::calculate_indexes() {
 auto Environment::startup() -> std::thread {
   validate(this->phase() == Phase::Assembly, "startup() may only be called during assembly phase!");
 
-  // build the dependency graph
-  for (auto* reactor : top_level_reactors_) {
-    build_dependency_graph(reactor);
-  }
-  calculate_indexes();
-
   log_.info() << "Starting the execution";
   phase_ = Phase::Startup;
 

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -28,7 +28,8 @@ thread_local const Worker* Worker::current_worker = nullptr;
 
 Worker::Worker(Worker&& work) // NOLINT(performance-noexcept-move-constructor)
     : scheduler_{work.scheduler_}
-    , identity_{work.identity_} {
+    , identity_{work.identity_}
+    , log_{std::move(work.log_)} {
   // Need to provide the move constructor in order to organize workers in a
   // std::vector. However, moving is not save if the thread is already running,
   // thus we throw an exception here if the worker is moved but the
@@ -43,10 +44,10 @@ void Worker::work() const {
   // initialize the current worker thread local variable
   current_worker = this;
 
-  log::Debug() << "(Worker " << this->identity_ << ") Starting";
+  log_.debug() << "Starting";
 
   if (identity_ == 0) {
-    log::Debug() << "(Worker 0) do the initial scheduling";
+    log_.debug() << "do the initial scheduling";
     scheduler_.schedule();
   }
 
@@ -71,12 +72,11 @@ void Worker::work() const {
     // continue otherwise
   }
 
-  log::Debug() << "(Worker " << identity_ << ") terminates";
+  log_.debug() << "terminates";
 }
 
 void Worker::execute_reaction(Reaction* reaction) const {
-  log::Debug() << "(Worker " << identity_ << ") "
-               << "execute reaction " << reaction->fqn();
+  log_.debug() << "execute reaction " << reaction->fqn();
 
   tracepoint(reactor_cpp, reaction_execution_starts, identity_, reaction->fqn(), scheduler_.logical_time());
   reaction->trigger();
@@ -87,7 +87,7 @@ void Scheduler::schedule() noexcept {
   bool found_ready_reactions = schedule_ready_reactions();
 
   while (!found_ready_reactions) {
-    log::Debug() << "(Scheduler) call next()";
+    log_.debug() << "call next()";
     next();
     reaction_queue_pos_ = 0;
 
@@ -106,9 +106,9 @@ auto ReadyQueue::pop() -> Reaction* {
 
   // If there is no ready reaction available, wait until there is one.
   while (old_size <= 0) {
-    log::Debug() << "(Worker " << Worker::current_worker_id() << ") Wait for work";
+    log_.debug() << "Worker " << Worker::current_worker_id() << " now waits for work";
     sem_.acquire();
-    log::Debug() << "(Worker " << Worker::current_worker_id() << ") Waking up";
+    log_.debug() << "Worker " << Worker::current_worker_id() << " wakes up";
     old_size = size_.fetch_sub(1, std::memory_order_acq_rel);
     // FIXME: Protect against underflow?
   }
@@ -143,16 +143,15 @@ void ReadyQueue::fill_up(std::vector<Reaction*>& ready_reactions) {
   // wakeup other workers_
   if (workers_to_wakeup > 0) {
     waiting_workers_ -= workers_to_wakeup;
-    log::Debug() << "Wakeup " << workers_to_wakeup << " workers";
+    log_.debug() << "Wakeup " << workers_to_wakeup << " workers";
     sem_.release(static_cast<int>(workers_to_wakeup));
   }
 }
 
 void Scheduler::terminate_all_workers() {
-  log::Debug() << "(Scheduler) Send termination signal to all workers";
+  log_.debug() << "Send termination signal to all workers";
   auto num_workers = environment_->num_workers();
   std::vector<Reaction*> null_reactions{num_workers, nullptr};
-  log::Debug() << null_reactions.size();
   ready_queue_.fill_up(null_reactions);
 }
 
@@ -165,7 +164,7 @@ auto Scheduler::schedule_ready_reactions() -> bool {
     vec_reaction.clear();
   }
 
-  log::Debug() << "(Scheduler) Scanning the reaction queue for ready reactions";
+  log_.debug() << "Scanning the reaction queue for ready reactions";
 
   // continue iterating over the reaction queue
   for (; reaction_queue_pos_ < reaction_queue_.size(); reaction_queue_pos_++) {
@@ -173,7 +172,7 @@ auto Scheduler::schedule_ready_reactions() -> bool {
 
     // any ready reactions of current priority?
     if (!reactions.empty()) {
-      log::Debug() << "(Scheduler) Process reactions of priority " << reaction_queue_pos_;
+      log_.debug() << "Process reactions of priority " << reaction_queue_pos_;
 
       // Make sure that any reaction is only executed once even if it
       // was triggered multiple times.
@@ -182,7 +181,7 @@ auto Scheduler::schedule_ready_reactions() -> bool {
 
       if constexpr (log::debug_enabled || tracing_enabled) { // NOLINT
         for (auto* reaction : reactions) {
-          log::Debug() << "(Scheduler) Reaction " << reaction->fqn() << " is ready for execution";
+          log_.debug() << "Reaction " << reaction->fqn() << " is ready for execution";
           tracepoint(reactor_cpp, trigger_reaction, reaction->container()->fqn(), reaction->name(), logical_time_);
         }
       }
@@ -195,12 +194,12 @@ auto Scheduler::schedule_ready_reactions() -> bool {
     }
   }
 
-  log::Debug() << "(Scheduler) Reached end of reaction queue";
+  log_.debug() << "Reached end of reaction queue";
   return false;
 }
 
 void Scheduler::start() {
-  log::Debug() << "Starting the scheduler...";
+  log_.debug() << "Starting the scheduler...";
 
   auto num_workers = environment_->num_workers();
   // initialize the reaction queue, set ports vector, and triggered reactions
@@ -215,7 +214,9 @@ void Scheduler::start() {
   // be moved.
   workers_.reserve(num_workers);
   for (unsigned i = 0; i < num_workers; i++) {
-    workers_.emplace_back(*this, i);
+    std::stringstream stream;
+    stream << "Worker " << environment_->name() << " " << i;
+    workers_.emplace_back(*this, i, stream.str());
     workers_.back().start_thread();
   }
 
@@ -256,7 +257,7 @@ void Scheduler::next() { // NOLINT
         // wait for a new asynchronous event
         cv_schedule_.wait(lock, [this]() { return !event_queue_.empty() || stop_; });
       } else {
-        log::Debug() << "No more events in queue_. -> Terminate!";
+        log_.debug() << "No more events in queue_. -> Terminate!";
         environment_->sync_shutdown();
       }
     }
@@ -264,14 +265,14 @@ void Scheduler::next() { // NOLINT
     while (actions == nullptr || actions->empty()) {
       if (stop_) {
         continue_execution_ = false;
-        log::Debug() << "Shutting down the scheduler";
+        log_.debug() << "Shutting down the scheduler";
         Tag t_next = Tag::from_logical_time(logical_time_).delay();
         if (!event_queue_.empty() && t_next == event_queue_.begin()->first) {
-          log::Debug() << "Schedule the last round of reactions including all "
+          log_.debug() << "Schedule the last round of reactions including all "
                           "termination reactions";
           actions = std::move(event_queue_.begin()->second);
           event_queue_.erase(event_queue_.begin());
-          log::Debug() << "advance logical time to tag [" << t_next.time_point() << ", " << t_next.micro_step() << "]";
+          log_.debug() << "advance logical time to tag [" << t_next.time_point() << ", " << t_next.micro_step() << "]";
           logical_time_.advance_to(t_next);
         } else {
           return;
@@ -313,7 +314,7 @@ void Scheduler::next() { // NOLINT
         actions = std::move(event_queue_.extract(event_queue_.begin()).mapped());
 
         // advance logical time
-        log::Debug() << "advance logical time to tag [" << t_next.time_point() << ", " << t_next.micro_step() << "]";
+        log_.debug() << "advance logical time to tag [" << t_next.time_point() << ", " << t_next.micro_step() << "]";
         logical_time_.advance_to(t_next);
       }
     }
@@ -325,14 +326,14 @@ void Scheduler::next() { // NOLINT
     action->setup();
   }
 
-  log::Debug() << "events: " << actions->size();
+  log_.debug() << "events: " << actions->size();
   for (const auto* action : *actions) {
-    log::Debug() << "Action " << action->fqn();
+    log_.debug() << "Action " << action->fqn();
     for (auto* reaction : action->triggers()) {
       // There is no need to acquire the mutex. At this point the scheduler
       // should be the only thread accessing the reaction queue as none of the
       // workers_ are running
-      log::Debug() << "insert reaction " << reaction->fqn() << " with index " << reaction->index();
+      log_.debug() << "insert reaction " << reaction->fqn() << " with index " << reaction->index();
       reaction_queue_[reaction->index()].push_back(reaction);
     }
   }
@@ -341,7 +342,8 @@ void Scheduler::next() { // NOLINT
 Scheduler::Scheduler(Environment* env)
     : using_workers_(env->num_workers() > 1)
     , environment_(env)
-    , ready_queue_(env->num_workers()) {
+    , log_("Scheduler " + env->name())
+    , ready_queue_(log_, env->num_workers()) {
   fill_action_list_pool();
 }
 
@@ -355,7 +357,7 @@ void Scheduler::fill_action_list_pool() {
 
 void Scheduler::schedule_sync(BaseAction* action, const Tag& tag) {
   reactor_assert(logical_time_ < tag);
-  log::Debug() << "Schedule action " << action->fqn() << (action->is_logical() ? " synchronously " : " asynchronously ")
+  log_.debug() << "Schedule action " << action->fqn() << (action->is_logical() ? " synchronously " : " asynchronously ")
                << " with tag [" << tag.time_point() << ", " << tag.micro_step() << "]";
   tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag);
 
@@ -403,7 +405,7 @@ auto Scheduler::schedule_async(BaseAction* action, const Duration& delay) -> Tag
 }
 
 void Scheduler::set_port(BasePort* port) {
-  log::Debug() << "Set port " << port->fqn();
+  log_.debug() << "Set port " << port->fqn();
 
   // We do not check here if port is already in the list. This means clean()
   // could be called multiple times for a single port. However, calling


### PR DESCRIPTION
This sets the stage for enabling enclaves in LF. This PR makes the following changes:
- Allow environments to be nested (i.e. contain each other in a tree hierarchy)
- Fix a couple of bugs that created races between schedulers.
- Improve debug logging to be able to distinguish the different environments