### PR TITLE
Optimization: use std::string_view in validation functions

### DIFF
--- a/include/reactor-cpp/assert.hh
+++ b/include/reactor-cpp/assert.hh
@@ -38,10 +38,10 @@ using EnvPhase = Environment::Phase;
 
 class ValidationError : public std::runtime_error {
 private:
-  static auto build_message(const std::string& msg) noexcept -> std::string;
+  static auto build_message(std::string_view msg) noexcept -> std::string;
 
 public:
-  explicit ValidationError(const std::string& msg)
+  explicit ValidationError(const std::string_view msg)
       : std::runtime_error(build_message(msg)) {}
 };
 
@@ -56,7 +56,7 @@ inline void print_debug_backtrace() {
 }
 #endif
 
-constexpr inline void validate([[maybe_unused]] bool condition, [[maybe_unused]] const std::string& message) {
+constexpr inline void validate([[maybe_unused]] bool condition, [[maybe_unused]] const std::string_view message) {
   if constexpr (runtime_validation) { // NOLINT
     if (!condition) {
 #ifdef __linux__

--- a/lib/assert.cc
+++ b/lib/assert.cc
@@ -10,7 +10,7 @@
 
 namespace reactor {
 
-auto ValidationError::build_message(const std::string& msg) noexcept -> std::string {
+auto ValidationError::build_message(const std::string_view msg) noexcept -> std::string {
   std::stringstream string_stream;
   string_stream << "Validation Error! \"" << msg << "\"";
   return string_stream.str();


### PR DESCRIPTION
This increases performance as std::string (often) requires dynamic memory allocation. This lead to situations where strings were allocated and deleted for every invocation of `validate` even if validation is switched off.

![all](https://user-images.githubusercontent.com/6460123/218986143-ac4df2d5-96fd-470e-bfb1-fd28b937ae87.png)

