### PR TITLE
Enclave connections and enclave coordination

### DIFF
--- a/include/reactor-cpp/action.hh
+++ b/include/reactor-cpp/action.hh
@@ -37,12 +37,17 @@ protected:
   virtual void cleanup() noexcept { present_ = false; }
 
   /**
-   * Use the given condition variable to wait until the given tag it safe to
-   * process or until the condition variable is notified.
+   * Use the given condition variable and lock to wait until the given tag it
+   * safe to process. The waiting is interrupted when the condition variable is
+   * notified (or has a spurious wakeup) and a call to the given `abort_waiting`
+   * function returns true. or until the condition variable is notified.
    *
-   * Returns true if the tag it safe to process.
+   * Returns false if the wait was interrupted and true otherwise. True
+   * indicates that the tag is safe to process.
    */
-  virtual auto acquire_tag([[maybe_unused]] std::condition_variable& cv, [[maybe_unused]] const Tag& tag) -> bool {
+  virtual auto acquire_tag([[maybe_unused]] const Tag& tag, [[maybe_unused]] std::unique_lock<std::mutex>& lock,
+                           [[maybe_unused]] std::condition_variable& cv,
+                           [[maybe_unused]] const std::function<bool(void)>& abort_waiting) -> bool {
     return true;
   }
 

--- a/include/reactor-cpp/action.hh
+++ b/include/reactor-cpp/action.hh
@@ -9,10 +9,12 @@
 #ifndef REACTOR_CPP_ACTION_HH
 #define REACTOR_CPP_ACTION_HH
 
+#include "assert.hh"
 #include "environment.hh"
 #include "fwd.hh"
 #include "logical_time.hh"
 #include "reactor.hh"
+#include "time_barrier.hh"
 #include "value_ptr.hh"
 
 #include <condition_variable>
@@ -45,10 +47,10 @@ protected:
    * Returns false if the wait was interrupted and true otherwise. True
    * indicates that the tag is safe to process.
    */
-  virtual auto acquire_tag([[maybe_unused]] const Tag& tag, [[maybe_unused]] std::unique_lock<std::mutex>& lock,
-                           [[maybe_unused]] std::condition_variable& cv,
-                           [[maybe_unused]] const std::function<bool(void)>& abort_waiting) -> bool {
-    return true;
+  virtual auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
+                           const std::function<bool(void)>& abort_waiting) -> bool {
+    reactor_assert(!logical_);
+    return PhysicalTimeBarrier::acquire_tag(tag, lock, cv, abort_waiting);
   }
 
   BaseAction(const std::string& name, Reactor* container, bool logical, Duration min_delay)

--- a/include/reactor-cpp/action.hh
+++ b/include/reactor-cpp/action.hh
@@ -84,6 +84,7 @@ public:
   void shutdown() final {}
 
   template <class Dur = Duration> void schedule(const ImmutableValuePtr<T>& value_ptr, Dur delay = Dur::zero());
+  auto schedule_at(const ImmutableValuePtr<T>& value_ptr, const Tag& tag) -> bool;
 
   template <class Dur = Duration> void schedule(MutableValuePtr<T>&& value_ptr, Dur delay = Dur::zero()) {
     schedule(ImmutableValuePtr<T>(std::forward<MutableValuePtr<T>>(value_ptr)), delay);
@@ -110,6 +111,7 @@ protected:
 
 public:
   template <class Dur = Duration> void schedule(Dur delay = Dur::zero());
+  auto schedule_at(const Tag& tag) -> bool;
 
   void startup() final {}
   void shutdown() final {}

--- a/include/reactor-cpp/action.hh
+++ b/include/reactor-cpp/action.hh
@@ -15,6 +15,7 @@
 #include "reactor.hh"
 #include "value_ptr.hh"
 
+#include <condition_variable>
 #include <map>
 #include <mutex>
 
@@ -34,6 +35,16 @@ protected:
 
   virtual void setup() noexcept { present_ = true; }
   virtual void cleanup() noexcept { present_ = false; }
+
+  /**
+   * Use the given condition variable to wait until the given tag it safe to
+   * process or until the condition variable is notified.
+   *
+   * Returns true if the tag it safe to process.
+   */
+  virtual auto acquire_tag([[maybe_unused]] std::condition_variable& cv, [[maybe_unused]] const Tag& tag) -> bool {
+    return true;
+  }
 
   BaseAction(const std::string& name, Reactor* container, bool logical, Duration min_delay)
       : ReactorElement(name, ReactorElement::Type::Action, container)

--- a/include/reactor-cpp/assert.hh
+++ b/include/reactor-cpp/assert.hh
@@ -69,11 +69,13 @@ constexpr inline void validate([[maybe_unused]] bool condition, [[maybe_unused]]
 
 // assert macro that avoids unused variable warnings
 #ifdef NDEBUG
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define reactor_assert(x)                                                                                              \
   do {                                                                                                                 \
     (void)sizeof(x);                                                                                                   \
   } while (0)
 #else
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define reactor_assert(x) assert(x)
 #endif
 

--- a/include/reactor-cpp/assert.hh
+++ b/include/reactor-cpp/assert.hh
@@ -67,16 +67,14 @@ constexpr inline void validate([[maybe_unused]] bool condition, [[maybe_unused]]
   }
 }
 
-// Use plain assert on Windows and when assertions are enabled.
-// Otherwise, the locations of assertion errors are not properly reported.
-#if defined(_WIN32) && !defined(NDEBUG)
-#define reactor_assert(condition) assert(condition)
+// assert macro that avoids unused variable warnings
+#ifdef NDEBUG
+#define reactor_assert(x)                                                                                              \
+  do {                                                                                                                 \
+    (void)sizeof(x);                                                                                                   \
+  } while (0)
 #else
-constexpr inline void reactor_assert([[maybe_unused]] bool condition) {
-  if constexpr (runtime_assertion) { // NOLINT
-    assert(condition);               // NOLINT
-  }
-}
+#define reactor_assert(x) assert(x)
 #endif
 
 template <typename E> constexpr auto extract_value(E enum_value) -> typename std::underlying_type<E>::type {

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -39,7 +39,7 @@ protected:
   virtual auto upstream_set_callback() noexcept -> PortCallback = 0;
 
 public:
-  void bind_upstream_port(Port<T>* port) {
+  virtual void bind_upstream_port(Port<T>* port) {
     reactor_assert(upstream_port_ == nullptr);
     upstream_port_ = port;
     port->register_set_callback(upstream_set_callback());
@@ -140,9 +140,10 @@ public:
     return released_time_ >= tag;
   }
 
-  void bind_downstream_port(Port<T>* port) override {
-    Connection<T>::bind_downstream_port(port);
-    // TODO register callback
+  void bind_upstream_port(Port<T>* port) override {
+    Connection<T>::bind_upstream_port(port);
+    port->environment()->scheduler()->register_release_tag_callback(
+        [this](const LogicalTime& tag) { release_tag(tag); });
   };
 };
 

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -48,9 +48,11 @@ public:
 };
 
 template <class T> class BaseDelayedConnection : public Connection<T> {
-public:
+protected:
   BaseDelayedConnection(const std::string& name, Reactor* container, bool is_logical, Duration delay)
       : Connection<T>(name, container, is_logical, delay) {}
+  BaseDelayedConnection(const std::string& name, Environment* environment, bool is_logical, Duration delay)
+      : Connection<T>(name, environment, is_logical, delay) {}
 
   inline auto upstream_set_callback() noexcept -> PortCallback override {
     return [this](const BasePort& port) {
@@ -64,6 +66,7 @@ public:
     };
   }
 
+public:
   void setup() noexcept override {
     Action<T>::setup();
 
@@ -91,10 +94,10 @@ public:
       : BaseDelayedConnection<T>(name, container, false, delay) {}
 };
 
-template <class T> class EnclaveConnection : public Connection<T> {
+template <class T> class EnclaveConnection : public BaseDelayedConnection<T> {
 public:
   EnclaveConnection(const std::string& name, Environment* enclave)
-    : Connection<T>(name, enclave, false, Duration::zero()) {}
+      : BaseDelayedConnection<T>(name, enclave, false, Duration::zero()) {}
 
   inline auto upstream_set_callback() noexcept -> PortCallback override {
     return [this](const BasePort& port) {

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -147,7 +147,11 @@ public:
 
     // Insert an empty event into the upstream event queue. This ensures that we
     // will get notified and woken up as soon as the tag becomes safe to process.
+    // It is important to unlock the mutex here. Otherwise we could enter a deadlock as
+    // scheduling the upstream event also requires holding the upstream mutex.
+    lock.unlock();
     bool result = this->upstream_port()->environment()->scheduler()->schedule_empty_async_at(tag);
+    lock.lock();
 
     // If inserting the empty event was not successful, then this is because the upstream
     // scheduler already processes a later event. In this case, it is safe to assume that

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -206,6 +206,8 @@ public:
     this->log_.debug() << "downstream tries to acquire tag " << tag;
     return PhysicalTimeBarrier::acquire_tag(tag, lock, cv, abort_waiting);
   }
+
+  void bind_upstream_port(Port<T>* port) override { Connection<T>::bind_upstream_port(port); }
 };
 
 } // namespace reactor

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -108,11 +108,13 @@ public:
       // of the downstream port. Hence, we can retrieve the current tag directly
       // without locking.
       auto tag = Tag::from_logical_time(scheduler->logical_time());
+      bool result{false};
       if constexpr (std::is_same<T, void>::value) {
-        this->schedule_at(tag);
+        result = this->schedule_at(tag);
       } else {
-        this->schedule_at(std::move(typed_port.get()), tag);
+        result = this->schedule_at(std::move(typed_port.get()), tag);
       }
+      reactor_assert(result);
     };
   }
 };

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -46,12 +46,12 @@ public:
 
 template <class T> class BaseDelayedConnection : public Connection<T> {
 public:
-  BaseDelayedConnection(const std::string& name, Reactor* container, bool is_physical, Duration delay)
-      : Connection<T>(name, container, is_physical, delay) {}
+  BaseDelayedConnection(const std::string& name, Reactor* container, bool is_logical, Duration delay)
+      : Connection<T>(name, container, is_logical, delay) {}
 
   inline auto upstream_set_callback() noexcept -> PortCallback override {
     return [this](const BasePort& port) {
-      // We know that port must be of type Port<T>*
+      // We know that port must be of type Port<T>
       auto& typed_port = reinterpret_cast<const Port<T>&>(port); // NOLINT
       if constexpr (std::is_same<T, void>::value) {
         this->schedule();

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -197,12 +197,11 @@ public:
   inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
                           const std::function<bool(void)>& abort_waiting) -> bool override {
     // Since this is a delayed connection, we can go back in time and need to
-    // acquire the latest tag upstream tag that can create an event at the given
+    // acquire the latest upstream tag that can create an event at the given
     // tag. We also need to consider that given a delay d and a tag g=(t, n),
     // for any value of n, g + d = (t, 0). Hence, we need to quire a tag with
     // the highest possible microstep value.
-    auto time_point = tag.time_point() - this->min_delay();
-    auto upstream_tag = Tag::max_for_timepoint(time_point);
+    auto upstream_tag = tag.subtract(this->min_delay());
     return EnclaveConnection<T>::acquire_tag(upstream_tag, lock, cv, abort_waiting);
   }
 };

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -142,7 +142,7 @@ public:
     }
 
     if (logical_time_barrier_.try_acquire_tag(tag)) {
-       return true;
+      return true;
     }
 
     // Insert an empty event into the upstream event queue. This ensures that we

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -200,6 +200,12 @@ public:
       }
     };
   }
+
+  inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
+                          const std::function<bool(void)>& abort_waiting) -> bool override {
+    this->log_.debug() << "downstream tries to acquire tag " << tag;
+    return PhysicalTimeBarrier::acquire_tag(tag, lock, cv, abort_waiting);
+  }
 };
 
 } // namespace reactor

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -118,7 +118,7 @@ public:
       auto& typed_port = reinterpret_cast<const Port<T>&>(port); // NOLINT
       const auto* scheduler = port.environment()->scheduler();
       // This callback will be called from a reaction executing in the context
-      // of the downstream port. Hence, we can retrieve the current tag directly
+      // of the upstream port. Hence, we can retrieve the current tag directly
       // without locking.
       auto tag = Tag::from_logical_time(scheduler->logical_time());
       bool result{false};

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -55,7 +55,7 @@ private:
 
   Scheduler scheduler_;
   Phase phase_{Phase::Construction};
-  TimePoint start_time_{};
+  Tag start_tag_{};
 
   const Duration timeout_{};
 
@@ -96,7 +96,7 @@ public:
   auto scheduler() noexcept -> Scheduler* { return &scheduler_; }
 
   [[nodiscard]] auto logical_time() const noexcept -> const LogicalTime& { return scheduler_.logical_time(); }
-  [[nodiscard]] auto start_time() const noexcept -> const TimePoint& { return start_time_; }
+  [[nodiscard]] auto start_tag() const noexcept -> const Tag& { return start_tag_; }
   [[nodiscard]] auto timeout() const noexcept -> const Duration& { return timeout_; }
 
   static auto physical_time() noexcept -> TimePoint { return get_physical_time(); }

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -105,6 +105,8 @@ public:
   [[nodiscard]] auto fast_fwd_execution() const noexcept -> bool { return fast_fwd_execution_; }
   [[nodiscard]] auto run_forever() const noexcept -> bool { return run_forever_; }
   [[nodiscard]] auto max_reaction_index() const noexcept -> unsigned int { return max_reaction_index_; }
+
+  friend Scheduler;
 };
 } // namespace reactor
 

--- a/include/reactor-cpp/impl/action_impl.hh
+++ b/include/reactor-cpp/impl/action_impl.hh
@@ -41,6 +41,19 @@ template <class T> template <class Dur> void Action<T>::schedule(const Immutable
   }
 }
 
+template <class Dur> void Action<void>::schedule(Dur delay) {
+  Duration time_delay = std::chrono::duration_cast<Duration>(delay);
+  reactor::validate(time_delay >= Duration::zero(), "Schedule cannot be called with a negative delay!");
+  auto* scheduler = environment()->scheduler();
+  if (is_logical()) {
+    time_delay += this->min_delay();
+    auto tag = Tag::from_logical_time(scheduler->logical_time()).delay(time_delay);
+    scheduler->schedule_sync(this, tag);
+  } else {
+    scheduler->schedule_async(this, time_delay);
+  }
+}
+
 template <class T> auto Action<T>::schedule_at(const ImmutableValuePtr<T>& value_ptr, const Tag& tag) -> bool {
   reactor::validate(value_ptr != nullptr, "Actions may not be scheduled with a nullptr value!");
 

--- a/include/reactor-cpp/impl/action_impl.hh
+++ b/include/reactor-cpp/impl/action_impl.hh
@@ -64,6 +64,7 @@ template <class T> auto Action<T>::schedule_at(const ImmutableValuePtr<T>& value
     if (result) {
       events_[tag] = value_ptr;
     }
+    return result;
   }
   return true;
 }

--- a/include/reactor-cpp/logical_time.hh
+++ b/include/reactor-cpp/logical_time.hh
@@ -41,6 +41,8 @@ public:
   [[nodiscard]]static auto max_for_timepoint(TimePoint time_point) noexcept -> Tag;
 
   [[nodiscard]] auto delay(Duration offset = Duration::zero()) const noexcept -> Tag;
+  [[nodiscard]] auto subtract(Duration offset = Duration::zero()) const noexcept -> Tag;
+  [[nodiscard]] auto decrement() const noexcept -> Tag;
 };
 
 // define all the comparison operators

--- a/include/reactor-cpp/logical_time.hh
+++ b/include/reactor-cpp/logical_time.hh
@@ -35,8 +35,10 @@ public:
   [[nodiscard]] auto time_point() const noexcept -> const TimePoint& { return time_point_; }
   [[nodiscard]] auto micro_step() const noexcept -> const mstep_t& { return micro_step_; }
 
-  static auto from_physical_time(TimePoint time_point) noexcept -> Tag;
-  static auto from_logical_time(const LogicalTime& logical_time) noexcept -> Tag;
+  [[nodiscard]]static auto from_physical_time(TimePoint time_point) noexcept -> Tag;
+  [[nodiscard]]static auto from_logical_time(const LogicalTime& logical_time) noexcept -> Tag;
+
+  [[nodiscard]]static auto max_for_timepoint(TimePoint time_point) noexcept -> Tag;
 
   [[nodiscard]] auto delay(Duration offset = Duration::zero()) const noexcept -> Tag;
 };

--- a/include/reactor-cpp/logical_time.hh
+++ b/include/reactor-cpp/logical_time.hh
@@ -90,6 +90,9 @@ auto inline operator>=(const Tag& tag, const LogicalTime& logical_time) noexcept
   return !(tag < logical_time);
 }
 
+auto operator<<(std::ostream& os, const Tag& tag) -> std::ostream&;
+auto operator<<(std::ostream& os, const LogicalTime& tag) -> std::ostream&;
+
 } // namespace reactor
 
 #endif // REACTOR_CPP_LOGICAL_TIME_HH

--- a/include/reactor-cpp/logical_time.hh
+++ b/include/reactor-cpp/logical_time.hh
@@ -35,10 +35,10 @@ public:
   [[nodiscard]] auto time_point() const noexcept -> const TimePoint& { return time_point_; }
   [[nodiscard]] auto micro_step() const noexcept -> const mstep_t& { return micro_step_; }
 
-  [[nodiscard]]static auto from_physical_time(TimePoint time_point) noexcept -> Tag;
-  [[nodiscard]]static auto from_logical_time(const LogicalTime& logical_time) noexcept -> Tag;
+  [[nodiscard]] static auto from_physical_time(TimePoint time_point) noexcept -> Tag;
+  [[nodiscard]] static auto from_logical_time(const LogicalTime& logical_time) noexcept -> Tag;
 
-  [[nodiscard]]static auto max_for_timepoint(TimePoint time_point) noexcept -> Tag;
+  [[nodiscard]] static auto max_for_timepoint(TimePoint time_point) noexcept -> Tag;
 
   [[nodiscard]] auto delay(Duration offset = Duration::zero()) const noexcept -> Tag;
   [[nodiscard]] auto subtract(Duration offset = Duration::zero()) const noexcept -> Tag;

--- a/include/reactor-cpp/logical_time.hh
+++ b/include/reactor-cpp/logical_time.hh
@@ -56,6 +56,7 @@ private:
 
 public:
   void advance_to(const Tag& tag);
+  void advance_to(const LogicalTime& time);
 
   [[nodiscard]] auto time_point() const noexcept -> TimePoint { return time_point_; }
   [[nodiscard]] auto micro_step() const noexcept -> mstep_t { return micro_step_; }

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -144,6 +144,8 @@ public:
   auto schedule_async(BaseAction* action, const Duration& delay) -> Tag;
   auto schedule_async_at(BaseAction* action, const Tag& tag) -> bool;
 
+  void inline notify() noexcept { cv_schedule_.notify_one(); }
+
   auto inline lock() noexcept -> auto { return std::unique_lock<std::mutex>(scheduling_mutex_); }
 
   void set_port(BasePort* port);

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -119,6 +119,7 @@ private:
   std::vector<ActionListPtr> action_list_pool_;
   static constexpr std::size_t action_list_pool_increment_{10};
   void fill_action_list_pool();
+  auto insert_event_at(const Tag& tag) -> const ActionListPtr&;
 
   std::vector<std::vector<BasePort*>> set_ports_;
   std::vector<std::vector<Reaction*>> triggered_reactions_;
@@ -147,6 +148,7 @@ public:
   void schedule_sync(BaseAction* action, const Tag& tag);
   auto schedule_async(BaseAction* action, const Duration& delay) -> Tag;
   auto schedule_async_at(BaseAction* action, const Tag& tag) -> bool;
+  auto schedule_empty_async_at(const Tag& tag) -> bool;
 
   void inline notify() noexcept { cv_schedule_.notify_one(); }
 

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -134,8 +134,6 @@ private:
   std::vector<ReleaseTagCallback> release_tag_callbacks_{};
   void release_current_tag();
 
-  auto acquire_tag(const Tag& tag) -> bool;
-
   void schedule() noexcept;
   auto schedule_ready_reactions() -> bool;
   void next();

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -135,6 +135,8 @@ private:
   std::vector<ReleaseTagCallback> release_tag_callbacks_{};
   void release_current_tag();
 
+  auto acquire_tag(const Tag& tag) -> bool;
+
   void schedule() noexcept;
   auto schedule_ready_reactions() -> bool;
   void next();

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -28,6 +28,8 @@
 
 namespace reactor {
 
+using ReleaseTagCallback = std::function<void(const LogicalTime&)>;
+
 // forward declarations
 class Scheduler;
 class Worker;
@@ -130,6 +132,9 @@ private:
   std::atomic<bool> stop_{false};
   bool continue_execution_{true};
 
+  std::vector<ReleaseTagCallback> release_tag_callbacks_{};
+  void release_current_tag();
+
   void schedule() noexcept;
   auto schedule_ready_reactions() -> bool;
   void next();
@@ -146,7 +151,7 @@ public:
 
   void inline notify() noexcept { cv_schedule_.notify_one(); }
 
-  auto inline lock() noexcept -> auto { return std::unique_lock<std::mutex>(scheduling_mutex_); }
+  auto inline lock() noexcept -> auto{ return std::unique_lock<std::mutex>(scheduling_mutex_); }
 
   void set_port(BasePort* port);
 
@@ -154,6 +159,8 @@ public:
 
   void start();
   void stop();
+
+  void register_release_tag_callback(const ReleaseTagCallback& callback);
 
   friend Worker;
 };

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -152,7 +152,7 @@ public:
 
   void inline notify() noexcept { cv_schedule_.notify_one(); }
 
-  auto inline lock() noexcept -> auto{ return std::unique_lock<std::mutex>(scheduling_mutex_); }
+  auto inline lock() noexcept -> auto { return std::unique_lock<std::mutex>(scheduling_mutex_); }
 
   void set_port(BasePort* port);
 

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -142,6 +142,7 @@ public:
 
   void schedule_sync(BaseAction* action, const Tag& tag);
   auto schedule_async(BaseAction* action, const Duration& delay) -> Tag;
+  auto schedule_async_at(BaseAction* action, const Tag& tag) -> bool;
 
   auto inline lock() noexcept -> auto { return std::unique_lock<std::mutex>(scheduling_mutex_); }
 

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -110,6 +110,10 @@ private:
 
   std::mutex scheduling_mutex_;
   std::condition_variable cv_schedule_;
+  // lock used to protect the scheduler from asynchronous requests (i.e. from
+  // enclaves pr federates). We hold the mutex from construction and release in
+  // start().
+  std::unique_lock<std::mutex> startup_lock_{scheduling_mutex_};
 
   std::shared_mutex mutex_event_queue_;
   std::map<Tag, ActionListPtr> event_queue_;

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -103,7 +103,6 @@ class Scheduler { // NOLINT
 private:
   const bool using_workers_;
   LogicalTime logical_time_{};
-  TimePoint last_observed_physical_time_{TimePoint::min()};
 
   Environment* environment_;
   std::vector<Worker> workers_{};

--- a/include/reactor-cpp/time_barrier.hh
+++ b/include/reactor-cpp/time_barrier.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 TU Dresden
+ * All rights reserved.
+ *
+ * Authors:
+ *   Christian Menard
+ */
+
+#ifndef REACTOR_CPP_TIME_BARRIER_HH
+#define REACTOR_CPP_TIME_BARRIER_HH
+
+#include "logical_time.hh"
+#include "time.hh"
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+
+namespace reactor {
+class PhysicalTimeBarrier {
+  inline static std::atomic<Duration> last_observed_physical_time_{Duration::zero()}; // NOLINT
+
+public:
+  static inline auto try_acquire_tag(const Tag& tag) -> bool {
+    // First, we compare against the last observed physical time. This variable
+    // serves as a cache for reading the physical clock. Reading from the physical
+    // clock can be slow and, thus, this is an optimization that ensures that we
+    // only read the clock when it is needed.
+    if (tag.time_point().time_since_epoch() < last_observed_physical_time_.load(std::memory_order_acquire)) {
+      return true;
+    }
+
+    auto physical_time = get_physical_time();
+    last_observed_physical_time_.store(physical_time.time_since_epoch(), std::memory_order_release);
+
+    return tag.time_point() < physical_time;
+  }
+
+  static inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
+                                 const std::function<bool(void)>& abort_waiting) {
+    if (try_acquire_tag(tag)) {
+      return true;
+    }
+    return !cv.wait_until(lock, tag.time_point(), abort_waiting);
+  }
+};
+} // namespace reactor
+
+#endif // REACTOR_CPP_TIME_BARRIER_HH

--- a/include/reactor-cpp/time_barrier.hh
+++ b/include/reactor-cpp/time_barrier.hh
@@ -9,6 +9,7 @@
 #ifndef REACTOR_CPP_TIME_BARRIER_HH
 #define REACTOR_CPP_TIME_BARRIER_HH
 
+#include "fwd.hh"
 #include "logical_time.hh"
 #include "time.hh"
 #include <atomic>
@@ -17,6 +18,7 @@
 #include <mutex>
 
 namespace reactor {
+
 class PhysicalTimeBarrier {
   inline static std::atomic<Duration> last_observed_physical_time_{Duration::zero()}; // NOLINT
 
@@ -44,6 +46,32 @@ public:
     return !cv.wait_until(lock, tag.time_point(), abort_waiting);
   }
 };
+
+class LogicalTimeBarrier {
+  std::mutex mutex_;
+  LogicalTime released_time_;
+
+public:
+  inline void release_tag(const LogicalTime& tag) {
+    std::lock_guard lock(mutex_);
+    released_time_.advance_to(tag);
+  }
+
+  inline auto try_acquire_tag(const Tag& tag) {
+    std::lock_guard lock(mutex_);
+    return tag <= released_time_;
+  }
+
+  inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
+                          const std::function<bool(void)>& abort_waiting) -> bool {
+    if (try_acquire_tag(tag)) {
+      return true;
+    }
+    cv.wait(lock, [this, &tag, &abort_waiting]() { return try_acquire_tag(tag) || abort_waiting(); });
+    return !abort_waiting();
+  }
+};
+
 } // namespace reactor
 
 #endif // REACTOR_CPP_TIME_BARRIER_HH

--- a/lib/action.cc
+++ b/lib/action.cc
@@ -41,11 +41,11 @@ void Timer::startup() {
     return;
   }
 
-  Tag tag_zero = Tag::from_physical_time(environment()->start_time());
+  const Tag& start_tag = environment()->start_tag();
   if (offset_ != Duration::zero()) {
-    environment()->scheduler()->schedule_sync(this, tag_zero.delay(offset_));
+    environment()->scheduler()->schedule_sync(this, start_tag.delay(offset_));
   } else {
-    environment()->scheduler()->schedule_sync(this, tag_zero);
+    environment()->scheduler()->schedule_sync(this, start_tag);
   }
 }
 

--- a/lib/action.cc
+++ b/lib/action.cc
@@ -74,19 +74,6 @@ void ShutdownTrigger::shutdown() {
   }
 }
 
-template <class Dur> void Action<void>::schedule(Dur delay) {
-  Duration time_delay = std::chrono::duration_cast<Duration>(delay);
-  reactor::validate(time_delay >= Duration::zero(), "Schedule cannot be called with a negative delay!");
-  auto* scheduler = environment()->scheduler();
-  if (is_logical()) {
-    time_delay += this->min_delay();
-    auto tag = Tag::from_logical_time(scheduler->logical_time()).delay(time_delay);
-    scheduler->schedule_sync(this, tag);
-  } else {
-    scheduler->schedule_async(this, time_delay);
-  }
-}
-
 auto Action<void>::schedule_at(const Tag& tag) -> bool {
   auto* scheduler = environment()->scheduler();
   if (is_logical()) {

--- a/lib/logical_time.cc
+++ b/lib/logical_time.cc
@@ -40,6 +40,12 @@ void LogicalTime::advance_to(const Tag& tag) {
   micro_step_ = tag.micro_step();
 }
 
+void LogicalTime::advance_to(const LogicalTime& time) {
+  reactor_assert(*this < Tag::from_logical_time(time));
+  time_point_ = time.time_point();
+  micro_step_ = time.micro_step();
+}
+
 auto operator==(const LogicalTime& logical_time, const Tag& tag) noexcept -> bool {
   return logical_time.time_point() == tag.time_point() && logical_time.micro_step() == tag.micro_step();
 }

--- a/lib/logical_time.cc
+++ b/lib/logical_time.cc
@@ -22,10 +22,14 @@ auto operator<(const Tag& lhs, const Tag& rhs) noexcept -> bool {
          (lhs.time_point() == rhs.time_point() && lhs.micro_step() < rhs.micro_step());
 }
 
-auto Tag::from_physical_time(TimePoint time_point) noexcept -> Tag { return Tag{time_point, 0}; }
+auto Tag::from_physical_time(TimePoint time_point) noexcept -> Tag { return {time_point, 0}; }
 
 auto Tag::from_logical_time(const LogicalTime& logical_time) noexcept -> Tag {
-  return Tag{logical_time.time_point(), logical_time.micro_step()};
+  return {logical_time.time_point(), logical_time.micro_step()};
+}
+
+auto Tag::max_for_timepoint(TimePoint time_point) noexcept -> Tag {
+  return {time_point, std::numeric_limits<mstep_t>::max()};
 }
 
 auto Tag::delay(Duration offset) const noexcept -> Tag {

--- a/lib/logical_time.cc
+++ b/lib/logical_time.cc
@@ -9,6 +9,7 @@
 #include "reactor-cpp/logical_time.hh"
 
 #include "reactor-cpp/assert.hh"
+#include <limits>
 
 namespace reactor {
 
@@ -58,6 +59,13 @@ auto operator<(const LogicalTime& logical_time, const Tag& tag) noexcept -> bool
 auto operator>(const LogicalTime& logical_time, const Tag& tag) noexcept -> bool {
   return logical_time.time_point() > tag.time_point() ||
          (logical_time.time_point() == tag.time_point() && logical_time.micro_step() > tag.micro_step());
+}
+
+auto operator<<(std::ostream& os, const Tag& tag) -> std::ostream& {
+  return os << '[' << tag.time_point() << ", " << tag.micro_step() << ']';
+}
+auto operator<<(std::ostream& os, const LogicalTime& tag) -> std::ostream& {
+  return os << '[' << tag.time_point() << ", " << tag.micro_step() << ']';
 }
 
 } // namespace reactor

--- a/lib/logical_time.cc
+++ b/lib/logical_time.cc
@@ -41,7 +41,7 @@ void LogicalTime::advance_to(const Tag& tag) {
 }
 
 void LogicalTime::advance_to(const LogicalTime& time) {
-  reactor_assert(*this < Tag::from_logical_time(time));
+  reactor_assert(*this <= Tag::from_logical_time(time));
   time_point_ = time.time_point();
   micro_step_ = time.micro_step();
 }

--- a/lib/reactor.cc
+++ b/lib/reactor.cc
@@ -169,11 +169,11 @@ auto Reactor::get_tag() const noexcept -> Tag {
 }
 
 auto Reactor::get_elapsed_logical_time() const noexcept -> Duration {
-  return get_logical_time() - environment()->start_time();
+  return get_logical_time() - environment()->start_tag().time_point();
 }
 
 auto Reactor::get_elapsed_physical_time() const noexcept -> Duration {
-  return get_physical_time() - environment()->start_time();
+  return get_physical_time() - environment()->start_tag().time_point();
 }
 
 } // namespace reactor

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -434,7 +434,10 @@ auto Scheduler::schedule_empty_async_at(const Tag& tag) -> bool {
   {
     std::lock_guard<std::mutex> lock_guard(scheduling_mutex_);
     if (tag <= logical_time_) {
-      return false;
+      // If we try to insert an empty event at the current logical time, then we
+      // succeeded because there must be an event at this tag that is currently
+      // processed.
+      return tag == logical_time_;
     }
     insert_event_at(tag);
   }

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -291,6 +291,7 @@ void Scheduler::next() { // NOLINT
       } else {
         // find the next tag
         auto t_next = event_queue_.begin()->first;
+        log_.debug() << "try to advance logical time to tag " << t_next;
 
         // synchronize with physical time if not in fast forward mode
         if (!environment_->fast_fwd_execution()) {
@@ -305,9 +306,12 @@ void Scheduler::next() { // NOLINT
         // Wait until all input actions mark the tag as safe to process.
         bool result{true};
         for (auto* action : environment_->input_actions_) {
-          result = action->acquire_tag(t_next, lock, cv_schedule_,
+          bool inner_result = action->acquire_tag(t_next, lock, cv_schedule_,
                                        [&t_next, this]() { return t_next != event_queue_.begin()->first; });
-          if (!result) {
+          // If the wait was aborted or if the next tag changed in the meantime,
+          // we need to break from the loop and continue with the main loop.
+          if (!inner_result || t_next != event_queue_.begin()->first) {
+            result = false;
             break;
           }
         }

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -307,7 +307,7 @@ void Scheduler::next() { // NOLINT
         bool result{true};
         for (auto* action : environment_->input_actions_) {
           bool inner_result = action->acquire_tag(t_next, lock, cv_schedule_,
-                                       [&t_next, this]() { return t_next != event_queue_.begin()->first; });
+                                                  [&t_next, this]() { return t_next != event_queue_.begin()->first; });
           // If the wait was aborted or if the next tag changed in the meantime,
           // we need to break from the loop and continue with the main loop.
           if (!inner_result || t_next != event_queue_.begin()->first) {

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -214,6 +214,11 @@ void Scheduler::start() {
   set_ports_.resize(num_workers);
   triggered_reactions_.resize(num_workers);
 
+  // release the scheduling mutex, allowing other asynchronous processes (i.e.
+  // enclaves or federates) to access the event queue and the current logical
+  // time.
+  startup_lock_.unlock();
+
   // Initialize and start the workers. By resizing the workers vector first,
   // we make sure that there is sufficient space for all the workers and non of
   // them needs to be moved. This is important because a running worker may not

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -391,7 +391,7 @@ auto Scheduler::schedule_async(BaseAction* action, const Duration& delay) -> Tag
     tag = Tag::from_physical_time(get_physical_time() + delay);
     schedule_sync(action, tag);
   }
-  cv_schedule_.notify_one();
+  notify();
   return tag;
 }
 
@@ -403,7 +403,7 @@ auto Scheduler::schedule_async_at(BaseAction* action, const Tag& tag) -> bool {
     }
     schedule_sync(action, tag);
   }
-  cv_schedule_.notify_one();
+  notify();
   return true;
 }
 
@@ -439,7 +439,7 @@ void Scheduler::set_port_helper(BasePort* port) {
 
 void Scheduler::stop() {
   stop_ = true;
-  cv_schedule_.notify_one();
+  notify();
 }
 
 } // namespace reactor

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -327,11 +327,11 @@ void Scheduler::next() { // NOLINT
         if (!environment_->input_actions_.empty()) {
           lock.unlock();
           bool result = acquire_tag(t_next);
+          lock.lock();
           if (!result) {
             // Start over if potentially a new event was inserted into the event queue
             continue;
           }
-          lock.lock();
         }
 
         // retrieve all events with tag equal to current logical time from the

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -275,7 +275,7 @@ void Scheduler::next() { // NOLINT
                           "termination reactions";
           triggered_actions_ = std::move(event_queue_.begin()->second);
           event_queue_.erase(event_queue_.begin());
-          log_.debug() << "advance logical time to tag [" << t_next.time_point() << ", " << t_next.micro_step() << "]";
+          log_.debug() << "advance logical time to tag " << t_next;
           logical_time_.advance_to(t_next);
         } else {
           return;
@@ -313,7 +313,7 @@ void Scheduler::next() { // NOLINT
         triggered_actions_ = std::move(event_queue_.extract(event_queue_.begin()).mapped());
 
         // advance logical time
-        log_.debug() << "advance logical time to tag [" << t_next.time_point() << ", " << t_next.micro_step() << "]";
+        log_.debug() << "advance logical time to tag " << t_next;
         logical_time_.advance_to(t_next);
       }
     }
@@ -352,7 +352,7 @@ void Scheduler::fill_action_list_pool() {
 
 void Scheduler::schedule_sync(BaseAction* action, const Tag& tag) {
   log_.debug() << "Schedule action " << action->fqn() << (action->is_logical() ? " synchronously " : " asynchronously ")
-               << " with tag [" << tag.time_point() << ", " << tag.micro_step() << "]";
+               << " with tag [" << tag;
   reactor_assert(logical_time_ < tag);
   tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag);
 

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -395,6 +395,18 @@ auto Scheduler::schedule_async(BaseAction* action, const Duration& delay) -> Tag
   return tag;
 }
 
+auto Scheduler::schedule_async_at(BaseAction* action, const Tag& tag) -> bool {
+  {
+    std::lock_guard<std::mutex> lock_guard(scheduling_mutex_);
+    if (tag <= logical_time_) {
+      return false;
+    }
+    schedule_sync(action, tag);
+  }
+  cv_schedule_.notify_one();
+  return true;
+}
+
 void Scheduler::set_port(BasePort* port) {
   log_.debug() << "Set port " << port->fqn();
 

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -202,6 +202,11 @@ auto Scheduler::schedule_ready_reactions() -> bool {
 void Scheduler::start() {
   log_.debug() << "Starting the scheduler...";
 
+  // Initialize our logical time to the value right before the start tag. This
+  // is important for usage with enclaves/federates, to indicate, that no events
+  // before the start tag ca be generated.
+  logical_time_.advance_to(environment_->start_tag().decrement());
+
   auto num_workers = environment_->num_workers();
   // initialize the reaction queue, set ports vector, and triggered reactions
   // vector

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -254,18 +254,19 @@ void Scheduler::next() { // NOLINT
   {
     std::unique_lock<std::mutex> lock{scheduling_mutex_};
 
-    // shutdown if there are no more events in the queue
-    if (event_queue_.empty() && !stop_) {
-      if (environment_->run_forever()) {
-        // wait for a new asynchronous event
-        cv_schedule_.wait(lock, [this]() { return !event_queue_.empty() || stop_; });
-      } else {
-        log_.debug() << "No more events in queue_. -> Terminate!";
-        environment_->sync_shutdown();
-      }
-    }
-
     while (triggered_actions_ == nullptr || triggered_actions_->empty()) {
+
+      // shutdown if there are no more events in the queue
+      if (event_queue_.empty() && !stop_) {
+        if (environment_->run_forever()) {
+          // wait for a new asynchronous event
+          cv_schedule_.wait(lock, [this]() { return !event_queue_.empty() || stop_; });
+        } else {
+          log_.debug() << "No more events in queue_. -> Terminate!";
+          environment_->sync_shutdown();
+        }
+      }
+
       if (triggered_actions_ != nullptr) {
         action_list_pool_.emplace_back(std::move(triggered_actions_));
       }


### PR DESCRIPTION
This adds 3 new connection types `EnclaveConnection`, `DelayedEnclaveConnection`, and `PhysicalEnclaveConnection` that facilitate the communication between scheduling enclaves. Additionally, this implements a coordination mechanism that allows individual enclaves to decide when it is safe to advance their logical time. For this, this PR introduces time barriers. They support a protocol where one party may try to acquire a tag and another party can release the tag. An acquire operation blocks until a tag greater or equal to the acquired one was released. This same mechanism can also be utilized for physical actions (here the physical clock continuously releases). Hence the mechanism implemented here unifies physical actions and inputs received from other enclaves (or later federates).