### PR TITLE
Fix race condition in time barriers

### DIFF
--- a/include/reactor-cpp/action.hh
+++ b/include/reactor-cpp/action.hh
@@ -47,10 +47,11 @@ protected:
    * Returns false if the wait was interrupted and true otherwise. True
    * indicates that the tag is safe to process.
    */
-  virtual auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
+  virtual auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock,
                            const std::function<bool(void)>& abort_waiting) -> bool {
     reactor_assert(!logical_);
-    return PhysicalTimeBarrier::acquire_tag(tag, lock, cv, abort_waiting);
+    reactor_assert(lock.owns_lock());
+    return PhysicalTimeBarrier::acquire_tag(tag, lock, environment()->scheduler(), abort_waiting);
   }
 
   BaseAction(const std::string& name, Reactor* container, bool logical, Duration min_delay)

--- a/include/reactor-cpp/assert.hh
+++ b/include/reactor-cpp/assert.hh
@@ -21,7 +21,7 @@ constexpr bool runtime_assertion = false;
 constexpr bool runtime_assertion = true;
 #endif
 
-#include "environment.hh"
+#include "fwd.hh"
 
 #include <cassert>
 #include <sstream>
@@ -37,7 +37,6 @@ constexpr bool runtime_assertion = true;
 #define reactor_assert(x) assert(x)
 
 namespace reactor {
-using EnvPhase = Environment::Phase;
 
 class ValidationError : public std::runtime_error {
 private:
@@ -74,31 +73,8 @@ template <typename E> constexpr auto extract_value(E enum_value) -> typename std
   return static_cast<typename std::underlying_type<E>::type>(enum_value);
 }
 
-inline void assert_phase([[maybe_unused]] const ReactorElement* ptr, [[maybe_unused]] EnvPhase phase) {
-  if constexpr (runtime_assertion) { // NOLINT
-    if (ptr->environment()->phase() != phase) {
-      auto enum_value_to_name = [](EnvPhase phase) -> std::string {
-        const std::map<EnvPhase, std::string> conversation_map = {
-            // NOLINT
-            {EnvPhase::Construction, "Construction"}, {EnvPhase::Assembly, "Assembly"},
-            {EnvPhase::Startup, "Startup"},           {EnvPhase::Execution, "Execution"},
-            {EnvPhase::Shutdown, "Shutdown"},         {EnvPhase::Deconstruction, "Deconstruction"}};
-        // in C++20 use .contains()
-        if (conversation_map.find(phase) != std::end(conversation_map)) {
-          return conversation_map.at(phase);
-        }
-        return "Unknown Phase: Value: " + std::to_string(extract_value(phase));
-      };
-#ifdef __linux__
-      print_debug_backtrace();
-#endif
+void assert_phase([[maybe_unused]] const ReactorElement* ptr, [[maybe_unused]] Phase phase);
 
-      // C++20 std::format
-      throw ValidationError("Expected Phase: " + enum_value_to_name(phase) +
-                            " Current Phase: " + enum_value_to_name(ptr->environment()->phase()));
-    }
-  }
-}
 } // namespace reactor
 
 #endif // REACTOR_CPP_ASSERT_HH

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -20,7 +20,6 @@
 #include "reactor.hh"
 #include "time.hh"
 #include "time_barrier.hh"
-#include <unistd.h>
 
 namespace reactor {
 
@@ -111,12 +110,14 @@ protected:
 
   EnclaveConnection(const std::string& name, Environment* enclave, const Duration& delay)
       : BaseDelayedConnection<T>(name, enclave, false, delay)
-      , log_{this->fqn()} {}
+      , log_{this->fqn()}
+      , logical_time_barrier_(enclave->scheduler()) {}
 
 public:
   EnclaveConnection(const std::string& name, Environment* enclave)
       : BaseDelayedConnection<T>(name, enclave, false, Duration::zero())
-      , log_{this->fqn()} {}
+      , log_{this->fqn()}
+      , logical_time_barrier_(enclave->scheduler()) {}
 
   inline auto upstream_set_callback() noexcept -> PortCallback override {
     return [this](const BasePort& port) {
@@ -137,7 +138,7 @@ public:
     };
   }
 
-  inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
+  inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock,
                           const std::function<bool(void)>& abort_waiting) -> bool override {
     reactor_assert(lock.owns_lock());
     log_.debug() << "downstream tries to acquire tag " << tag;
@@ -235,7 +236,7 @@ public:
   inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock,
                           const std::function<bool(void)>& abort_waiting) -> bool override {
     this->log_.debug() << "downstream tries to acquire tag " << tag;
-    return PhysicalTimeBarrier::acquire_tag(tag, lock, this->environmet()->scheduler(), abort_waiting);
+    return PhysicalTimeBarrier::acquire_tag(tag, lock, this->environment()->scheduler(), abort_waiting);
   }
 
   void bind_upstream_port(Port<T>* port) override { Connection<T>::bind_upstream_port(port); }

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -26,10 +26,9 @@ constexpr unsigned int default_max_reaction_index = 0;
 constexpr bool default_run_forever = false;
 constexpr bool default_fast_fwd_execution = false;
 
-class Environment {
-public:
-  enum class Phase { Construction = 0, Assembly = 1, Startup = 2, Execution = 3, Shutdown = 4, Deconstruction = 5 };
+enum class Phase { Construction = 0, Assembly = 1, Startup = 2, Execution = 3, Shutdown = 4, Deconstruction = 5 };
 
+class Environment {
 private:
   using Dependency = std::pair<Reaction*, Reaction*>;
 

--- a/include/reactor-cpp/fwd.hh
+++ b/include/reactor-cpp/fwd.hh
@@ -16,8 +16,10 @@ namespace reactor {
 class BaseAction;
 class BasePort;
 class Environment;
+enum class Phase;
 class Reaction;
 class Reactor;
+class ReactorElement;
 class Scheduler;
 class Tag;
 

--- a/include/reactor-cpp/time_barrier.hh
+++ b/include/reactor-cpp/time_barrier.hh
@@ -11,11 +11,9 @@
 
 #include "fwd.hh"
 #include "logical_time.hh"
+#include "scheduler.hh"
 #include "time.hh"
-#include <atomic>
-#include <condition_variable>
 #include <functional>
-#include <mutex>
 
 namespace reactor {
 
@@ -38,36 +36,38 @@ public:
     return tag.time_point() < physical_time;
   }
 
-  static inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
-                                 const std::function<bool(void)>& abort_waiting) {
+  static inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, Scheduler* scheduler,
+                                 const std::function<bool(void)>& abort_waiting) -> bool {
     if (try_acquire_tag(tag)) {
       return true;
     }
-    return !cv.wait_until(lock, tag.time_point(), abort_waiting);
+    return scheduler->wait_until(lock, tag.time_point(), abort_waiting);
   }
 };
 
 class LogicalTimeBarrier {
-  std::mutex mutex_;
+private:
   LogicalTime released_time_;
+  Scheduler* scheduler_;
 
 public:
+  LogicalTimeBarrier(Scheduler* scheduler)
+      : scheduler_(scheduler) {}
+
   inline void release_tag(const LogicalTime& tag) {
-    std::lock_guard lock(mutex_);
+    auto lock = scheduler_->lock();
     released_time_.advance_to(tag);
   }
 
-  inline auto try_acquire_tag(const Tag& tag) {
-    std::lock_guard lock(mutex_);
-    return tag <= released_time_;
-  }
+  // The caller must hold a lock on the scheduler mutex
+  inline auto try_acquire_tag(const Tag& tag) { return tag <= released_time_; }
 
-  inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock, std::condition_variable& cv,
+  inline auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock,
                           const std::function<bool(void)>& abort_waiting) -> bool {
     if (try_acquire_tag(tag)) {
       return true;
     }
-    cv.wait(lock, [this, &tag, &abort_waiting]() { return try_acquire_tag(tag) || abort_waiting(); });
+    scheduler_->wait(lock, [this, &tag, &abort_waiting]() { return try_acquire_tag(tag) || abort_waiting(); });
     return !abort_waiting();
   }
 };

--- a/lib/action.cc
+++ b/lib/action.cc
@@ -18,7 +18,7 @@ namespace reactor {
 void BaseAction::register_trigger(Reaction* reaction) {
   reactor_assert(reaction != nullptr);
   reactor_assert(this->environment() == reaction->environment());
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
   validate(this->container() == reaction->container(),
            "Action triggers must belong to the same reactor as the triggered "
            "reaction");
@@ -29,7 +29,7 @@ void BaseAction::register_trigger(Reaction* reaction) {
 void BaseAction::register_scheduler(Reaction* reaction) {
   reactor_assert(reaction != nullptr);
   reactor_assert(this->environment() == reaction->environment());
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
   // the reaction must belong to the same reactor as this action
   validate(this->container() == reaction->container(), "Scheduable actions must belong to the same reactor as the "
                                                        "triggered reaction");

--- a/lib/assert.cc
+++ b/lib/assert.cc
@@ -7,6 +7,7 @@
  */
 
 #include "reactor-cpp/assert.hh"
+#include "reactor-cpp/environment.hh"
 
 namespace reactor {
 
@@ -14,6 +15,32 @@ auto ValidationError::build_message(const std::string_view msg) noexcept -> std:
   std::stringstream string_stream;
   string_stream << "Validation Error! \"" << msg << "\"";
   return string_stream.str();
+}
+
+void assert_phase([[maybe_unused]] const ReactorElement* ptr, [[maybe_unused]] Phase phase) {
+  if constexpr (runtime_assertion) { // NOLINT
+    if (ptr->environment()->phase() != phase) {
+      auto enum_value_to_name = [](Phase phase) -> std::string {
+        const std::map<Phase, std::string> conversation_map = {
+            // NOLINT
+            {Phase::Construction, "Construction"}, {Phase::Assembly, "Assembly"},
+            {Phase::Startup, "Startup"},           {Phase::Execution, "Execution"},
+            {Phase::Shutdown, "Shutdown"},         {Phase::Deconstruction, "Deconstruction"}};
+        // in C++20 use .contains()
+        if (conversation_map.find(phase) != std::end(conversation_map)) {
+          return conversation_map.at(phase);
+        }
+        return "Unknown Phase: Value: " + std::to_string(extract_value(phase));
+      };
+#ifdef __linux__
+      print_debug_backtrace();
+#endif
+
+      // C++20 std::format
+      throw ValidationError("Expected Phase: " + enum_value_to_name(phase) +
+                            " Current Phase: " + enum_value_to_name(ptr->environment()->phase()));
+    }
+  }
 }
 
 } // namespace reactor

--- a/lib/port.cc
+++ b/lib/port.cc
@@ -20,7 +20,7 @@ void BasePort::base_bind_to(BasePort* port) {
   reactor_assert(this->environment() == port->environment());
   validate(!port->has_inward_binding(), "Ports may only be connected once");
   validate(!port->has_anti_dependencies(), "Ports with anti dependencies may not be connected to other ports");
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
   if (this->is_input() && port->is_input()) {
     validate(this->container() == port->container()->container(),
              "An input port A may only be bound to another input port B if B is contained by a reactor that in turn is "
@@ -52,7 +52,7 @@ void BasePort::register_dependency(Reaction* reaction, bool is_trigger) noexcept
   reactor_assert(reaction != nullptr);
   reactor_assert(this->environment() == reaction->environment());
   validate(!this->has_outward_bindings(), "Dependencies may no be declared on ports with an outward binding!");
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
 
   if (this->is_input()) {
     validate(this->container() == reaction->container(), "Dependent input ports must belong to the same reactor as the "
@@ -74,7 +74,7 @@ void BasePort::register_antidependency(Reaction* reaction) noexcept {
   reactor_assert(reaction != nullptr);
   reactor_assert(this->environment() == reaction->environment());
   validate(!this->has_inward_binding(), "Antidependencies may no be declared on ports with an inward binding!");
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
 
   if (this->is_output()) {
     validate(this->container() == reaction->container(),

--- a/lib/reaction.cc
+++ b/lib/reaction.cc
@@ -27,7 +27,7 @@ Reaction::Reaction(const std::string& name, int priority, Reactor* container, st
 void Reaction::declare_trigger(BaseAction* action) {
   reactor_assert(action != nullptr);
   reactor_assert(this->environment() == action->environment());
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
   validate(this->container() == action->container(), "Action triggers must belong to the same reactor as the triggered "
                                                      "reaction");
 
@@ -39,7 +39,7 @@ void Reaction::declare_trigger(BaseAction* action) {
 void Reaction::declare_schedulable_action(BaseAction* action) {
   reactor_assert(action != nullptr);
   reactor_assert(this->environment() == action->environment());
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
   validate(this->container() == action->container(), "Scheduable actions must belong to the same reactor as the "
                                                      "triggered reaction");
 
@@ -51,8 +51,7 @@ void Reaction::declare_schedulable_action(BaseAction* action) {
 void Reaction::declare_trigger(BasePort* port) {
   reactor_assert(port != nullptr);
   reactor_assert(this->environment() == port->environment());
-  reactor_assert(this->environment()->phase() == Environment::Phase::Assembly);
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
 
   if (port->is_input()) {
     validate(this->container() == port->container(),
@@ -73,7 +72,7 @@ void Reaction::declare_trigger(BasePort* port) {
 void Reaction::declare_dependency(BasePort* port) {
   reactor_assert(port != nullptr);
   reactor_assert(this->environment() == port->environment());
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
 
   if (port->is_input()) {
     validate(this->container() == port->container(), "Dependent input ports must belong to the same reactor as the "
@@ -91,7 +90,7 @@ void Reaction::declare_dependency(BasePort* port) {
 void Reaction::declare_antidependency(BasePort* port) {
   reactor_assert(port != nullptr);
   reactor_assert(this->environment() == port->environment());
-  assert_phase(this, Environment::Phase::Assembly);
+  assert_phase(this, Phase::Assembly);
 
   if (port->is_output()) {
     validate(this->container() == port->container(), "Antidependent output ports must belong to the same reactor as "
@@ -127,7 +126,7 @@ void Reaction::set_deadline_impl(Duration deadline, const std::function<void(voi
 }
 
 void Reaction::set_index(unsigned index) {
-  validate(this->environment()->phase() == Environment::Phase::Assembly,
+  validate(this->environment()->phase() == Phase::Assembly,
            "Reaction indexes may only be set during assembly phase!");
   this->index_ = index;
 }

--- a/lib/reaction.cc
+++ b/lib/reaction.cc
@@ -126,8 +126,7 @@ void Reaction::set_deadline_impl(Duration deadline, const std::function<void(voi
 }
 
 void Reaction::set_index(unsigned index) {
-  validate(this->environment()->phase() == Phase::Assembly,
-           "Reaction indexes may only be set during assembly phase!");
+  validate(this->environment()->phase() == Phase::Assembly, "Reaction indexes may only be set during assembly phase!");
   this->index_ = index;
 }
 

--- a/lib/reactor.cc
+++ b/lib/reactor.cc
@@ -24,8 +24,8 @@ ReactorElement::ReactorElement(const std::string& name, ReactorElement::Type typ
   reactor_assert(container != nullptr);
   this->environment_ = container->environment(); // NOLINT container can be NULL
   reactor_assert(this->environment_ != nullptr);
-  validate(this->environment_->phase() == Environment::Phase::Construction ||
-               (type == Type::Action && this->environment_->phase() == Environment::Phase::Assembly),
+  validate(this->environment_->phase() == Phase::Construction ||
+               (type == Type::Action && this->environment_->phase() == Phase::Assembly),
            "Reactor elements can only be created during construction phase!");
   // We need a reinterpret_cast here as the derived class is not yet created
   // when this constructor is executed. dynamic_cast only works for
@@ -65,7 +65,7 @@ ReactorElement::ReactorElement(const std::string& name, ReactorElement::Type typ
     , environment_(environment) {
   reactor_assert(environment != nullptr);
   validate(type == Type::Reactor || type == Type::Action, "Only reactors and actions can be owned by the environment!");
-  validate(this->environment_->phase() == Environment::Phase::Construction,
+  validate(this->environment_->phase() == Phase::Construction,
            "Reactor elements can only be created during construction phase!");
 
   switch (type) {
@@ -89,8 +89,8 @@ Reactor::Reactor(const std::string& name, Environment* environment)
 
 void Reactor::register_action([[maybe_unused]] BaseAction* action) {
   reactor_assert(action != nullptr);
-  reactor::validate(this->environment()->phase() == Environment::Phase::Construction ||
-                        this->environment()->phase() == Environment::Phase::Assembly,
+  reactor::validate(this->environment()->phase() == Phase::Construction ||
+                        this->environment()->phase() == Phase::Assembly,
                     "Actions can only be registered during construction phase!");
   [[maybe_unused]] bool result = actions_.insert(action).second;
   reactor_assert(result);
@@ -99,7 +99,7 @@ void Reactor::register_action([[maybe_unused]] BaseAction* action) {
 
 void Reactor::register_input(BasePort* port) {
   reactor_assert(port != nullptr);
-  reactor::validate(this->environment()->phase() == Environment::Phase::Construction,
+  reactor::validate(this->environment()->phase() == Phase::Construction,
                     "Ports can only be registered during construction phase!");
   [[maybe_unused]] bool result = inputs_.insert(port).second;
   reactor_assert(result);
@@ -108,7 +108,7 @@ void Reactor::register_input(BasePort* port) {
 
 void Reactor::register_output(BasePort* port) {
   reactor_assert(port != nullptr);
-  reactor::validate(this->environment()->phase() == Environment::Phase::Construction,
+  reactor::validate(this->environment()->phase() == Phase::Construction,
                     "Ports can only be registered during construction phase!");
   [[maybe_unused]] bool result = inputs_.insert(port).second;
   reactor_assert(result);
@@ -118,7 +118,7 @@ void Reactor::register_output(BasePort* port) {
 void Reactor::register_reaction([[maybe_unused]] Reaction* reaction) {
   reactor_assert(reaction != nullptr);
 
-  validate(this->environment()->phase() == Environment::Phase::Construction,
+  validate(this->environment()->phase() == Phase::Construction,
            "Reactions can only be registered during construction phase!");
   [[maybe_unused]] bool result = reactions_.insert(reaction).second;
   reactor_assert(result);
@@ -127,7 +127,7 @@ void Reactor::register_reaction([[maybe_unused]] Reaction* reaction) {
 
 void Reactor::register_reactor([[maybe_unused]] Reactor* reactor) {
   reactor_assert(reactor != nullptr);
-  validate(this->environment()->phase() == Environment::Phase::Construction,
+  validate(this->environment()->phase() == Phase::Construction,
            "Reactions can only be registered during construction phase!");
   [[maybe_unused]] bool result = reactors_.insert(reactor).second;
   reactor_assert(result);
@@ -135,7 +135,7 @@ void Reactor::register_reactor([[maybe_unused]] Reactor* reactor) {
 }
 
 void Reactor::startup() {
-  reactor_assert(environment()->phase() == Environment::Phase::Startup);
+  reactor_assert(environment()->phase() == Phase::Startup);
   log::Debug() << "Starting up reactor " << fqn();
   // call startup on all contained objects
   for (auto* base_action : actions_) {
@@ -156,7 +156,7 @@ void Reactor::startup() {
 }
 
 void Reactor::shutdown() {
-  reactor_assert(environment()->phase() == Environment::Phase::Shutdown);
+  reactor_assert(environment()->phase() == Phase::Shutdown);
   log::Debug() << "Terminating reactor " << fqn();
   // call shutdown on all contained objects
   for (auto* action : actions_) {

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -523,7 +523,7 @@ void Scheduler::register_release_tag_callback(const ReleaseTagCallback& callback
   // Callbacks should only be registered during assembly, which happens strictly
   // sequentially. Therefore, we should be fine accessing the vector directly
   // and do not need to lock.
-  validate(environment_->phase() <= Environment::Phase::Assembly,
+  validate(environment_->phase() <= Phase::Assembly,
            "registering callbacks is only allowed during construction and assembly");
   release_tag_callbacks_.push_back(callback);
 }


### PR DESCRIPTION
There was a race condition in the main synchronization primitive that we use to coordinate enclaves. Our code used two separate locks, one for protecting the variable holding the last released tag and another one for receiving updates from the scheduler. However, we can only use one of the locks when calling `wait` on our condition variable. This creates a race between updating the wait condition (i.e. releasing a tag) and actually starting the wait under the second lock ([Here](https://www.modernescpp.com/index.php/c-core-guidelines-be-aware-of-the-traps-of-condition-variables) is an explanation, see "An atomic predicate") This PR refactors the time barriers, such that the global scheduler lock is also used to protect our local `released_tag_` variable.

This adresses https://github.com/lf-lang/lingua-franca/issues/1746