### PR TITLE
Fix validate method and fix incorrect phase checks

### DIFF
--- a/include/reactor-cpp/assert.hh
+++ b/include/reactor-cpp/assert.hh
@@ -9,6 +9,19 @@
 #ifndef REACTOR_CPP_ASSERT_HH
 #define REACTOR_CPP_ASSERT_HH
 
+#include "reactor-cpp/config.hh"
+#include "reactor-cpp/fwd.hh"
+
+#include <cassert>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#ifdef __linux__
+#include <execinfo.h>
+#include <unistd.h>
+#endif
+
 #ifdef REACTOR_CPP_VALIDATE
 constexpr bool runtime_validation = true;
 #else
@@ -19,18 +32,6 @@ constexpr bool runtime_validation = false;
 constexpr bool runtime_assertion = false;
 #else
 constexpr bool runtime_assertion = true;
-#endif
-
-#include "fwd.hh"
-
-#include <cassert>
-#include <sstream>
-#include <stdexcept>
-#include <string>
-
-#ifdef __linux__
-#include <execinfo.h>
-#include <unistd.h>
 #endif
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -55,7 +55,8 @@ void Environment::register_reactor(Reactor* reactor) {
 
 void Environment::register_input_action(BaseAction* action) {
   reactor_assert(action != nullptr);
-  validate(this->phase() == Phase::Construction, "Input actions may only be registered during construction phase!");
+  validate(this->phase() == Phase::Construction || this->phase() == Phase::Assembly,
+           "Input actions may only be registered during construction or assembly phase!");
   [[maybe_unused]] bool result = input_actions_.insert(action).second;
   reactor_assert(result);
   run_forever_ = true;

--- a/lib/reactor.cc
+++ b/lib/reactor.cc
@@ -65,14 +65,16 @@ ReactorElement::ReactorElement(const std::string& name, ReactorElement::Type typ
     , environment_(environment) {
   reactor_assert(environment != nullptr);
   validate(type == Type::Reactor || type == Type::Action, "Only reactors and actions can be owned by the environment!");
-  validate(this->environment_->phase() == Phase::Construction,
-           "Reactor elements can only be created during construction phase!");
 
   switch (type) {
   case Type::Action:
+    validate(this->environment_->phase() == Phase::Construction || this->environment_->phase() == Phase::Assembly,
+             "Actions can only be created during construction or assembly phase!");
     Statistics::increment_actions();
     break;
   case Type::Reactor:
+    validate(this->environment_->phase() == Phase::Construction,
+             "Reactors can only be created during construction phase!");
     Statistics::increment_reactor_instances();
     break;
   default:


### PR DESCRIPTION
This PR fixes a bug in `assert.hh`. Since we did not include the config header before accessing the configuration macro `REACTOR_CPP_VALIDATE` runtime validation was always disabled (if the user did not include `config.hh` before `assert.hh` in the compilation unit. 

This bug in `validat` also masked a couple of problems with incorrect checks. Those checks are also corrected in this PR.
