### PR TITLE
Port graph

### DIFF
--- a/examples/power_train/main.cc
+++ b/examples/power_train/main.cc
@@ -164,13 +164,14 @@ auto main() -> int {
   Brake brakes{&env};
   Engine engine{&env};
 
+  env.draw_connection(left_pedal.angle, brake_control.angle, ConnectionProperties{});
+  env.draw_connection(left_pedal.angle, engine_control.on_off, ConnectionProperties{});
+  env.draw_connection(brake_control.force, brakes.force, ConnectionProperties{});
+  env.draw_connection(right_pedal.angle, engine_control.angle, ConnectionProperties{});
+  env.draw_connection(engine_control.check, right_pedal.check, ConnectionProperties{});
+  env.draw_connection(engine_control.torque, engine.torque, ConnectionProperties{});
+
   env.assemble();
-  left_pedal.angle.bind_to(&brake_control.angle);
-  left_pedal.on_off.bind_to(&engine_control.on_off);
-  brake_control.force.bind_to(&brakes.force);
-  right_pedal.angle.bind_to(&engine_control.angle);
-  engine_control.check.bind_to(&right_pedal.check);
-  engine_control.torque.bind_to(&engine.torque);
 
   env.export_dependency_graph("graph.dot");
 

--- a/include/reactor-cpp/action.hh
+++ b/include/reactor-cpp/action.hh
@@ -73,8 +73,8 @@ template <class T> class Action : public BaseAction {
 private:
   ImmutableValuePtr<T> value_ptr_{nullptr};
 
-  std::map<Tag, ImmutableValuePtr<T>> events_;
-  std::mutex mutex_events_;
+  std::map<Tag, ImmutableValuePtr<T>> events_{};
+  std::mutex mutex_events_{};
 
 protected:
   void setup() noexcept override;

--- a/include/reactor-cpp/action.hh
+++ b/include/reactor-cpp/action.hh
@@ -14,6 +14,7 @@
 #include "fwd.hh"
 #include "logical_time.hh"
 #include "reactor.hh"
+#include "reactor_element.hh"
 #include "time_barrier.hh"
 #include "value_ptr.hh"
 
@@ -27,7 +28,7 @@ class BaseAction : public ReactorElement {
 private:
   std::set<Reaction*> triggers_{};
   std::set<Reaction*> schedulers_{};
-  const Duration min_delay_{};
+  const Duration min_delay_{0};
   const bool logical_{true};
   bool present_{false};
 
@@ -48,22 +49,13 @@ protected:
    * indicates that the tag is safe to process.
    */
   virtual auto acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock,
-                           const std::function<bool(void)>& abort_waiting) -> bool {
-    reactor_assert(!logical_);
-    reactor_assert(lock.owns_lock());
-    return PhysicalTimeBarrier::acquire_tag(tag, lock, environment()->scheduler(), abort_waiting);
-  }
+                           const std::function<bool(void)>& abort_waiting) -> bool;
 
   BaseAction(const std::string& name, Reactor* container, bool logical, Duration min_delay)
       : ReactorElement(name, ReactorElement::Type::Action, container)
       , min_delay_(min_delay)
       , logical_(logical) {}
-  BaseAction(const std::string& name, Environment* environment, bool logical, Duration min_delay)
-      : ReactorElement(name, ReactorElement::Type::Action, environment)
-      , min_delay_(min_delay)
-      , logical_(logical) {
-    environment->register_input_action(this);
-  }
+  BaseAction(const std::string& name, Environment* environment, bool logical, Duration min_delay);
 
 public:
   [[nodiscard]] auto inline triggers() const noexcept -> const auto& { return triggers_; }
@@ -150,12 +142,7 @@ public:
 
 template <class T> class PhysicalAction : public Action<T> {
 public:
-  PhysicalAction(const std::string& name, Reactor* container)
-      : Action<T>(name, container, false, Duration::zero()) {
-    // all physical actions act as input actions to the program as they can be
-    // scheduled from external threads
-    container->environment()->register_input_action(this);
-  }
+  PhysicalAction(const std::string& name, Reactor* container);
 };
 
 template <class T> class LogicalAction : public Action<T> {
@@ -166,8 +153,8 @@ public:
 
 class Timer : public BaseAction {
 private:
-  const Duration offset_{};
-  const Duration period_{};
+  const Duration offset_{0};
+  const Duration period_{0};
 
   void cleanup() noexcept final;
 

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -132,7 +132,7 @@ public:
       // of the upstream port. Hence, we can retrieve the current tag directly
       // without locking.
       auto tag = Tag::from_logical_time(scheduler->logical_time());
-      bool result{false}; // NOLINT value set is not used
+      [[maybe_unused]] bool result{false}; // NOLINT value set is not used
       if constexpr (std::is_same<T, void>::value) {
         result = this->schedule_at(tag);
       } else {

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -132,7 +132,7 @@ public:
       // of the upstream port. Hence, we can retrieve the current tag directly
       // without locking.
       auto tag = Tag::from_logical_time(scheduler->logical_time());
-      bool result{false}; //NOLINT value set is not used
+      bool result{false}; // NOLINT value set is not used
       if constexpr (std::is_same<T, void>::value) {
         result = this->schedule_at(tag);
       } else {

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -124,18 +124,21 @@ public:
       , log_{this->fqn()} {};
 
   inline auto upstream_set_callback() noexcept -> PortCallback override {
-    return [&](const BasePort& port) { // NOLINT unused this
+    return [this](const BasePort& port) {
+      // We know that port must be of type Port<T>
+      auto& typed_port = reinterpret_cast<const Port<T>&>(port); // NOLINT
+      const auto* scheduler = port.environment()->scheduler();
       // This callback will be called from a reaction executing in the context
       // of the upstream port. Hence, we can retrieve the current tag directly
       // without locking.
+      auto tag = Tag::from_logical_time(scheduler->logical_time());
+      bool result{false};
       if constexpr (std::is_same<T, void>::value) {
-        this->schedule_at(Tag::from_logical_time(port.environment()->scheduler()->logical_time()));
+        result = this->schedule_at(tag);
       } else {
-        // We know that port must be of type Port<T>
-        auto& typed_port = reinterpret_cast<const Port<T>&>(port); // NOLINT
-        this->schedule_at(std::move(typed_port.get()),
-                          Tag::from_logical_time(port.environment()->scheduler()->logical_time()));
+        result = this->schedule_at(std::move(typed_port.get()), tag);
       }
+      reactor_assert(result);
     };
   }
 

--- a/include/reactor-cpp/connection.hh
+++ b/include/reactor-cpp/connection.hh
@@ -132,7 +132,7 @@ public:
       // of the upstream port. Hence, we can retrieve the current tag directly
       // without locking.
       auto tag = Tag::from_logical_time(scheduler->logical_time());
-      bool result{false};
+      bool result{false}; //NOLINT value set is not used
       if constexpr (std::is_same<T, void>::value) {
         result = this->schedule_at(tag);
       } else {

--- a/include/reactor-cpp/connection_properties.hh
+++ b/include/reactor-cpp/connection_properties.hh
@@ -21,7 +21,11 @@ struct ConnectionProperties {
   Environment* enclave_{nullptr};
 
   auto operator<(const ConnectionProperties& elem2) const noexcept -> bool {
-    return this->type_ < elem2.type_ && this->delay_ < elem2.delay_;
+    return (this->type_ < elem2.type_) || (this->type_ == elem2.type_ && this->delay_ < elem2.delay_);
+  }
+
+  auto operator==(const ConnectionProperties& elem2) const noexcept -> bool {
+    return this->type_ == elem2.type_ && this->delay_ == elem2.delay_;
   }
 };
 

--- a/include/reactor-cpp/connection_properties.hh
+++ b/include/reactor-cpp/connection_properties.hh
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023 TU Dresden
+ * All rights reserved.
+ *
+ * Authors:
+ *   Tassilo Tanneberger
+ */
+
+#ifndef REACTOR_CPP_CONNECTION_PROPERTIES_HH
+#define REACTOR_CPP_CONNECTION_PROPERTIES_HH
+
+#include "fwd.hh"
+#include "logical_time.hh"
+
+namespace reactor {
+
+enum ConnectionType { Normal, Delayed, Enclaved, Physical, DelayedEnclaved, PhysicalEnclaved, Plugin, Invalid };
+struct ConnectionProperties {
+  ConnectionType type_ = ConnectionType::Normal;
+  Duration delay_{0};
+  Environment* enclave_{nullptr};
+};
+
+} // namespace reactor
+
+#endif // REACTOR_CPP_CONNECTION_PROPERTIES_HH

--- a/include/reactor-cpp/connection_properties.hh
+++ b/include/reactor-cpp/connection_properties.hh
@@ -19,6 +19,10 @@ struct ConnectionProperties {
   ConnectionType type_ = ConnectionType::Normal;
   Duration delay_{0};
   Environment* enclave_{nullptr};
+
+  auto operator<(const ConnectionProperties& elem2) const noexcept -> bool {
+    return this->type_ < elem2.type_ && this->delay_ < elem2.delay_;
+  }
 };
 
 } // namespace reactor

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -82,14 +82,13 @@ public:
     this->draw_connection(&source, &sink, properties);
   }
 
-  template <class T>
-  void draw_connection(Port<T>* source, Port<T>* sink, ConnectionProperties properties) {
-      if (top_environment_ == nullptr || top_environment_ == this) {
-        log::Debug() << "drawing connection: " << source << " --> " << sink;
-        graph_.add_edge(source, sink, properties);
-      } else {
-        top_environment_->draw_connection(source, sink, properties);
-      }
+  template <class T> void draw_connection(Port<T>* source, Port<T>* sink, ConnectionProperties properties) {
+    if (top_environment_ == nullptr || top_environment_ == this) {
+      log::Debug() << "drawing connection: " << source << " --> " << sink;
+      graph_.add_edge(source, sink, properties);
+    } else {
+      top_environment_->draw_connection(source, sink, properties);
+    }
   }
 
   void optimize();

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -81,7 +81,16 @@ public:
   template <class T> void draw_connection(Port<T>& source, Port<T>& sink, ConnectionProperties properties) {
     this->draw_connection(&source, &sink, properties);
   }
-  void draw_connection(BasePort* source, BasePort* sink, ConnectionProperties properties);
+
+  template <class T>
+  void draw_connection(Port<T>* source, Port<T>* sink, ConnectionProperties properties) {
+      if (top_environment_ == nullptr || top_environment_ == this) {
+        log::Debug() << "drawing connection: " << source << " --> " << sink;
+        graph_.add_edge(source, sink, properties);
+      } else {
+        top_environment_->draw_connection(source, sink, properties);
+      }
+  }
 
   void optimize();
 

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -44,7 +44,6 @@ private:
   /// Set of actions that act as an input to the reactor program in this environment
   std::set<BaseAction*> input_actions_{};
   std::set<Reaction*> reactions_{};
-  std::set<BasePort*> ports_{};
   std::vector<Dependency> dependencies_{};
 
   /// The environment containing this environment. nullptr if this is the top environment

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -13,10 +13,11 @@
 #include <string>
 #include <vector>
 
+#include "connection_properties.hh"
 #include "fwd.hh"
+#include "graph.hh"
 #include "reactor-cpp/logging.hh"
 #include "reactor-cpp/time.hh"
-#include "reactor.hh"
 #include "scheduler.hh"
 
 namespace reactor {
@@ -43,6 +44,7 @@ private:
   /// Set of actions that act as an input to the reactor program in this environment
   std::set<BaseAction*> input_actions_{};
   std::set<Reaction*> reactions_{};
+  std::set<BasePort*> ports_{};
   std::vector<Dependency> dependencies_{};
 
   /// The environment containing this environment. nullptr if this is the top environment
@@ -58,6 +60,9 @@ private:
 
   const Duration timeout_{};
 
+  Graph<BasePort*, ConnectionProperties> graph_{};
+  Graph<BasePort*, ConnectionProperties> optimized_graph_{};
+
   void build_dependency_graph(Reactor* reactor);
   void calculate_indexes();
 
@@ -72,7 +77,14 @@ public:
 
   auto name() -> const std::string& { return name_; }
 
+  // this method draw a connection between two graph elements with some properties
+  void draw_connection(BasePort& source, BasePort& sink, ConnectionProperties properties);
+  void draw_connection(BasePort* source, BasePort* sink, ConnectionProperties properties);
+
+  void optimize();
+
   void register_reactor(Reactor* reactor);
+  void register_port(BasePort* port) noexcept;
   void register_input_action(BaseAction* action);
   void assemble();
   auto startup() -> std::thread;

--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -78,7 +78,9 @@ public:
   auto name() -> const std::string& { return name_; }
 
   // this method draw a connection between two graph elements with some properties
-  void draw_connection(BasePort& source, BasePort& sink, ConnectionProperties properties);
+  template <class T> void draw_connection(Port<T>& source, Port<T>& sink, ConnectionProperties properties) {
+    this->draw_connection(&source, &sink, properties);
+  }
   void draw_connection(BasePort* source, BasePort* sink, ConnectionProperties properties);
 
   void optimize();

--- a/include/reactor-cpp/graph.hh
+++ b/include/reactor-cpp/graph.hh
@@ -38,7 +38,7 @@ public:
       : graph_(std::move(graph.graph_)) {}
   ~Graph() noexcept = default;
 
-  auto operator=(Graph other) noexcept -> Graph& {
+  auto operator=(const Graph other) noexcept -> Graph& {
     graph_ = other.graph_;
     return *this;
   }

--- a/include/reactor-cpp/graph.hh
+++ b/include/reactor-cpp/graph.hh
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2023 TU Dresden
+ * All rights reserved.
+ *
+ * Authors:
+ *   Tassilo Tanneberger
+ */
+
+#ifndef REACTOR_CPP_GRAPH_HH
+#define REACTOR_CPP_GRAPH_HH
+
+#include <iostream>
+#include <map>
+#include <optional>
+#include <vector>
+
+namespace reactor {
+// this graph is special, because to every edge properties are annotated
+template <class E, class P> class Graph {
+private:
+  std::map<E, std::vector<std::pair<P, E>>> graph_;
+
+  // custom compare operator this is required if u want special key values in std::map
+  // this is required for the Graph::get_edges() method
+  using map_key = std::pair<E, P>;
+  struct map_key_compare {
+    // TODO: check this maybe will cause some very funny TM problems later
+    auto operator()(const map_key& left_site, const map_key& right_site) const -> bool {
+      return left_site.first < right_site.first;
+    }
+  };
+
+public:
+  Graph() noexcept = default;
+  Graph(const Graph& graph) noexcept
+      : graph_(graph.graph_) {}
+  Graph(const Graph&& graph) noexcept
+      : graph_(std::move(graph.graph_)) {}
+  ~Graph() noexcept = default;
+
+  auto operator=(Graph other) noexcept -> Graph& {
+    graph_ = other.graph_;
+    return *this;
+  }
+
+  auto operator=(Graph&& other) noexcept -> Graph& {
+    graph_ = std::move(other.graph_);
+    return *this;
+  }
+
+  // adds a single edge to the graph structure
+  void add_edge(E source, E destination, P properties) noexcept {
+    if (graph_.find(source) == std::end(graph_)) {
+      std::vector<std::pair<P, E>> edges{std::make_pair(properties, destination)};
+      graph_[source] = edges;
+    } else {
+      graph_[source].emplace_back(properties, destination);
+    }
+  }
+
+  // this groups connections by same source and properties
+  [[nodiscard]] auto get_edges() const noexcept -> std::map<map_key, std::vector<E>, map_key_compare> {
+    std::map<map_key, std::vector<E>, map_key_compare> all_edges{};
+    for (auto const& [source, sinks] : graph_) {
+
+      for (const auto& sink : sinks) {
+        auto key = std::make_pair(source, sink.first);
+        all_edges.try_emplace(key, std::vector<E>{});
+        all_edges[key].push_back(sink.second);
+      }
+    }
+
+    return all_edges;
+  };
+
+  // deletes the content of the graph
+  void clear() noexcept { graph_.clear(); }
+
+  // returns all the sources from the graph
+  [[nodiscard]] auto keys() const noexcept -> std::vector<E> {
+    std::vector<E> keys{};
+    for (auto it = graph_.begin(); it != graph_.end(); ++it) {
+      keys.push_back(it->first);
+    }
+    return keys;
+  }
+
+  // returns the spanning tree of a given source including properties
+  [[nodiscard]] auto spanning_tree(E source) noexcept -> std::map<E, std::vector<std::pair<P, E>>> {
+    std::map<E, std::vector<std::pair<P, E>>> tree{};
+    std::vector<E> work_nodes{source};
+
+    while (!work_nodes.empty()) {
+      auto parent = *work_nodes.begin();
+
+      for (auto child : graph_[parent]) {
+        // figuring out the properties until this node
+        std::vector<std::pair<P, E>> parent_properties{};
+        if (tree.find(parent) != std::end(tree)) {
+          // this if should always be the case except the first time when tree is empty
+          parent_properties = tree[parent]; // TODO: make sure this is a copy otherwise we change this properties as
+                                            // well
+        }
+
+        // appending the new property and inserting into the tree
+        parent_properties.push_back(child);
+        work_nodes.push_back(child.second);
+        tree[child.second] = parent_properties;
+      }
+
+      work_nodes.erase(std::begin(work_nodes));
+    }
+
+    return tree;
+  }
+
+  [[nodiscard]] auto get_destinations(E source) const noexcept -> std::vector<std::pair<P, E>> {
+    return graph_[source];
+  }
+
+  [[nodiscard]] auto get_upstream(E vertex) const noexcept -> std::optional<E> {
+    for (const auto& [source, sinks] : graph_) {
+      if (sinks.second.contains(vertex)) {
+        return source;
+      }
+    }
+  }
+
+  friend auto operator<<(std::ostream& outstream, const Graph& graph) -> std::ostream& {
+    for (auto const& [source, destinations] : graph.graph_) {
+      for (auto destination : destinations) {
+        outstream << source << " --> " << destination.second << std::endl;
+      }
+    }
+    return outstream;
+  }
+};
+} // namespace reactor
+#endif // REACTOR_CPP_GRAPH_HH

--- a/include/reactor-cpp/graph.hh
+++ b/include/reactor-cpp/graph.hh
@@ -24,9 +24,8 @@ private:
   // this is required for the Graph::get_edges() method
   using map_key = std::pair<E, P>;
   struct map_key_compare {
-    // TODO: check this maybe will cause some very funny TM problems later
     auto operator()(const map_key& left_site, const map_key& right_site) const -> bool {
-      return left_site.first < right_site.first;
+      return left_site.first < right_site.first && left_site.second < right_site.second;
     }
   };
 

--- a/include/reactor-cpp/graph.hh
+++ b/include/reactor-cpp/graph.hh
@@ -25,7 +25,8 @@ private:
   using map_key = std::pair<E, P>;
   struct map_key_compare {
     auto operator()(const map_key& left_site, const map_key& right_site) const -> bool {
-      return left_site.first < right_site.first && left_site.second < right_site.second;
+      return left_site.first < right_site.first ||
+             (left_site.second == right_site.second && left_site.second < right_site.second);
     }
   };
 

--- a/include/reactor-cpp/impl/action_impl.hh
+++ b/include/reactor-cpp/impl/action_impl.hh
@@ -108,7 +108,7 @@ PhysicalAction<T>::PhysicalAction(const std::string& name, reactor::Reactor* con
     : Action<T>(name, container, false, Duration::zero()) {
   // all physical actions act as input actions to the program as they can be
   // scheduled from external threads
-  this->environment()->insert_input_action(this);
+  this->environment()->register_input_action(this);
 }
 
 } // namespace reactor

--- a/include/reactor-cpp/impl/action_impl.hh
+++ b/include/reactor-cpp/impl/action_impl.hh
@@ -9,8 +9,10 @@
 #ifndef REACTOR_CPP_IMPL_ACTION_IMPL_HH
 #define REACTOR_CPP_IMPL_ACTION_IMPL_HH
 
-#include "../assert.hh"
-#include "../environment.hh"
+#include "reactor-cpp/assert.hh"
+#include "reactor-cpp/environment.hh"
+#include "reactor-cpp/reactor.hh"
+
 #include <iterator>
 #include <mutex>
 
@@ -99,6 +101,14 @@ template <class T> void Action<T>::setup() noexcept {
 template <class T> void Action<T>::cleanup() noexcept {
   BaseAction::cleanup();
   value_ptr_ = nullptr;
+}
+
+template <class T>
+PhysicalAction<T>::PhysicalAction(const std::string& name, reactor::Reactor* container)
+    : Action<T>(name, container, false, Duration::zero()) {
+  // all physical actions act as input actions to the program as they can be
+  // scheduled from external threads
+  this->environment()->insert_input_action(this);
 }
 
 } // namespace reactor

--- a/include/reactor-cpp/impl/port_impl.hh
+++ b/include/reactor-cpp/impl/port_impl.hh
@@ -70,32 +70,25 @@ void Port<T>::instantiate_connection_to(const ConnectionProperties& properties,
   auto index = this->container()->number_of_connections();
 
   if (properties.type_ == ConnectionType::Delayed) {
-    connection =
-        std::make_unique<DelayedConnection<T>>(this->name() + "_delayed_connection_" + std::to_string(index), // NOLINT
-                                               this->container(),                                             // NOLINT
-                                               properties.delay_);                                            // NOLINT
+    connection = std::make_unique<DelayedConnection<T>>(this->name() + "_delayed_connection_" + std::to_string(index),
+                                                        this->container(), properties.delay_);
   }
   if (properties.type_ == ConnectionType::Physical) {
-    connection = std::make_unique<PhysicalConnection<T>>(this->name() + "_physical_connection_" +
-                                                             std::to_string(index), // NOLINT
-                                                         this->container(),         // NOLINT
-                                                         properties.delay_);        // NOLINT
+    connection = std::make_unique<PhysicalConnection<T>>(this->name() + "_physical_connection_" + std::to_string(index),
+                                                         this->container(), properties.delay_);
   }
   if (properties.type_ == ConnectionType::Enclaved) {
     connection = // NOLINT
-        std::make_unique<EnclaveConnection<T>>(this->name() + "_enclave_connection_" + std::to_string(index),
-                                               enclave); // NOLINT
+        std::make_unique<EnclaveConnection<T>>(this->name() + "_enclave_connection_" + std::to_string(index), enclave);
   }
   if (properties.type_ == ConnectionType::DelayedEnclaved) {
     connection = // NOLINT
-        std::make_unique<DelayedEnclaveConnection<T>>(this->name() + "_delayed_enclave_connection_" +
-                                                          std::to_string(index), // NOLINT
-                                                      enclave,                   // NOLINT
-                                                      properties.delay_);        // NOLINT
+        std::make_unique<DelayedEnclaveConnection<T>>(
+            this->name() + "_delayed_enclave_connection_" + std::to_string(index), enclave, properties.delay_);
   }
   if (properties.type_ == ConnectionType::PhysicalEnclaved) {
-    connection = std::make_unique<PhysicalEnclaveConnection<T>>(                          // NOLINT
-        this->name() + "_physical_enclave_connection_" + std::to_string(index), enclave); // NOLINT
+    connection = std::make_unique<PhysicalEnclaveConnection<T>>(
+        this->name() + "_physical_enclave_connection_" + std::to_string(index), enclave);
   }
 
   // if the connection here is null we have a vaulty enum value

--- a/include/reactor-cpp/impl/port_impl.hh
+++ b/include/reactor-cpp/impl/port_impl.hh
@@ -9,11 +9,21 @@
 #ifndef REACTOR_CPP_IMPL_PORT_IMPL_HH
 #define REACTOR_CPP_IMPL_PORT_IMPL_HH
 
-#include "../assert.hh"
-#include "../environment.hh"
+#include "reactor-cpp/assert.hh"
+#include "reactor-cpp/connection.hh"
+#include "reactor-cpp/environment.hh"
 #include "reactor-cpp/port.hh"
 
 namespace reactor {
+
+// connection fwd
+
+template <class T> class Connection;
+template <class T> class DelayedConnection;
+template <class T> class PhysicalConnection;
+template <class T> class EnclaveConnection;
+template <class T> class DelayedEnclaveConnection;
+template <class T> class PhysicalEnclaveConnection;
 
 template <class T> [[maybe_unused]] auto Port<T>::typed_outward_bindings() const noexcept -> const std::set<Port<T>*>& {
   // HACK this cast is ugly but should be safe as long as we only allow to
@@ -44,6 +54,50 @@ template <class T> auto Port<T>::get() const noexcept -> const ImmutableValuePtr
     return typed_inward_binding()->get();
   }
   return value_ptr_;
+}template <class T>
+void Port<T>::pull_connection(const ConnectionProperties& properties, const std::vector<BasePort*>& downstream) {
+  Connection<T>* connection = nullptr;
+  if (downstream.empty()) {
+    return;
+  }
+
+  // normal connections should be handled by environment
+  reactor_assert(properties.type_ != ConnectionType::Normal);
+
+  Environment* enclave = downstream[0]->environment();
+  auto index = this->container()->number_of_connections();
+
+  if (properties.type_ == ConnectionType::Delayed) {
+    connection = new DelayedConnection<T>(this->name() + "_delayed_connection_" + std::to_string(index), // NOLINT
+                                          this->container(),                                             // NOLINT
+                                          properties.delay_);                                            // NOLINT
+  }
+  if (properties.type_ == ConnectionType::Physical) {
+    connection = new PhysicalConnection<T>(this->name() + "_physical_connection_" + std::to_string(index), // NOLINT
+                                           this->container(),                                              // NOLINT
+                                           properties.delay_);                                             // NOLINT
+  }
+  if (properties.type_ == ConnectionType::Enclaved) {
+    connection =                                                                                          // NOLINT
+        new EnclaveConnection<T>(this->name() + "_enclave_connection_" + std::to_string(index), enclave); // NOLINT
+  }
+  if (properties.type_ == ConnectionType::DelayedEnclaved) {
+    connection =                                                                                               // NOLINT
+        new DelayedEnclaveConnection<T>(this->name() + "_delayed_enclave_connection_" + std::to_string(index), // NOLINT
+                                        enclave,                                                               // NOLINT
+                                        properties.delay_);                                                    // NOLINT
+  }
+  if (properties.type_ == ConnectionType::PhysicalEnclaved) {
+    connection = new PhysicalEnclaveConnection<T>(                                        // NOLINT
+        this->name() + "_physical_enclave_connection_" + std::to_string(index), enclave); // NOLINT
+  }
+
+  // if the connection here is null we have a vaulty enum value
+  reactor_assert(connection != nullptr);
+  connection->bind_downstream_ports(downstream);
+  connection->bind_upstream_port(this);
+  this->register_set_callback(connection->upstream_set_callback());
+  this->container()->register_connection(connection);
 }
 
 } // namespace reactor

--- a/include/reactor-cpp/impl/port_impl.hh
+++ b/include/reactor-cpp/impl/port_impl.hh
@@ -54,7 +54,8 @@ template <class T> auto Port<T>::get() const noexcept -> const ImmutableValuePtr
     return typed_inward_binding()->get();
   }
   return value_ptr_;
-}template <class T>
+}
+template <class T>
 void Port<T>::pull_connection(const ConnectionProperties& properties, const std::vector<BasePort*>& downstream) {
   Connection<T>* connection = nullptr;
   if (downstream.empty()) {

--- a/include/reactor-cpp/port.hh
+++ b/include/reactor-cpp/port.hh
@@ -13,11 +13,11 @@
 #include <vector>
 
 #include "assert.hh"
+#include "connection_properties.hh"
 #include "fwd.hh"
 #include "multiport.hh"
 #include "reactor_element.hh"
 #include "value_ptr.hh"
-#include "connection_properties.hh"
 
 namespace reactor {
 
@@ -42,7 +42,6 @@ protected:
   BasePort(const std::string& name, PortType type, Reactor* container)
       : ReactorElement(name, match_port_enum(type), container)
       , type_(type) {}
-
 
   void register_dependency(Reaction* reaction, bool is_trigger) noexcept;
   void register_antidependency(Reaction* reaction) noexcept;
@@ -72,9 +71,7 @@ protected:
   }
 
 public:
-  void set_inward_binding(BasePort* port) noexcept {
-    inward_binding_ = port;
-  }
+  void set_inward_binding(BasePort* port) noexcept { inward_binding_ = port; }
   void add_outward_binding(BasePort* port) noexcept {
     outward_bindings_.insert(port); // NOLINT
   }

--- a/include/reactor-cpp/port.hh
+++ b/include/reactor-cpp/port.hh
@@ -76,7 +76,8 @@ public:
     outward_bindings_.insert(port); // NOLINT
   }
 
-  virtual void pull_connection(const ConnectionProperties& properties, const std::vector<BasePort*>& downstreams) = 0;
+  virtual void instantiate_connection_to(const ConnectionProperties& properties,
+                                         const std::vector<BasePort*>& downstreams) = 0;
 
   [[nodiscard]] inline auto is_input() const noexcept -> bool { return type_ == PortType::Input; }
   [[nodiscard]] inline auto is_output() const noexcept -> bool { return type_ == PortType::Output; }
@@ -123,7 +124,8 @@ public:
   Port(const std::string& name, PortType type, Reactor* container)
       : BasePort(name, type, container) {}
 
-  void pull_connection(const ConnectionProperties& properties, const std::vector<BasePort*>& downstream) override;
+  void instantiate_connection_to(const ConnectionProperties& properties,
+                                 const std::vector<BasePort*>& downstream) override;
   [[nodiscard]] auto typed_inward_binding() const noexcept -> Port<T>*;
   [[nodiscard]] auto typed_outward_bindings() const noexcept -> const std::set<Port<T>*>&;
 
@@ -152,7 +154,8 @@ public:
   Port(const std::string& name, PortType type, Reactor* container)
       : BasePort(name, type, container) {}
 
-  void pull_connection(const ConnectionProperties& properties, const std::vector<BasePort*>& downstream) override;
+  void instantiate_connection_to(const ConnectionProperties& properties,
+                                 const std::vector<BasePort*>& downstream) override;
   [[nodiscard]] auto typed_inward_binding() const noexcept -> Port<void>*;
   [[nodiscard]] auto typed_outward_bindings() const noexcept -> const std::set<Port<void>*>&;
 

--- a/include/reactor-cpp/reaction.hh
+++ b/include/reactor-cpp/reaction.hh
@@ -12,7 +12,9 @@
 #include <functional>
 #include <set>
 
-#include "reactor.hh"
+#include "fwd.hh"
+#include "logical_time.hh"
+#include "reactor_element.hh"
 
 namespace reactor {
 

--- a/include/reactor-cpp/reactor-cpp.hh
+++ b/include/reactor-cpp/reactor-cpp.hh
@@ -12,6 +12,7 @@
 // include everything that is needed to use reactor-cpp
 #include "action.hh"
 #include "connection.hh"
+#include "connection_properties.hh"
 #include "environment.hh"
 #include "logging.hh"
 #include "logical_time.hh"

--- a/include/reactor-cpp/reactor.hh
+++ b/include/reactor-cpp/reactor.hh
@@ -13,45 +13,12 @@
 #include <sstream>
 #include <string>
 
-#include "fwd.hh"
+#include "action.hh"
+#include "environment.hh"
 #include "logical_time.hh"
+#include "reactor_element.hh"
 
 namespace reactor {
-class ReactorElement { // NOLINT
-private:
-  const std::string name_{};
-  std::string fqn_{};
-
-  // The reactor owning this element
-  Reactor* const container_{nullptr};
-  Environment* environment_{};
-
-  auto fqn_detail(std::stringstream& string_stream) const noexcept -> std::stringstream&;
-
-public:
-  enum class Type { Action, Port, Reaction, Reactor, Input, Output };
-
-  ReactorElement(const std::string& name, Type type, Reactor* container);
-  ReactorElement(const std::string& name, Type type, Environment* environment);
-  virtual ~ReactorElement() = default;
-
-  // not copyable, but movable
-  ReactorElement(const ReactorElement&) = delete;
-  ReactorElement(ReactorElement&&) = default;
-
-  [[nodiscard]] auto container() const noexcept -> Reactor* { return container_; }
-
-  [[nodiscard]] auto inline name() const noexcept -> const std::string& { return name_; }
-  [[nodiscard]] auto inline fqn() const noexcept -> const std::string& { return fqn_; }
-  [[nodiscard]] auto inline environment() noexcept -> Environment* { return environment_; }
-  [[nodiscard]] auto inline environment() const noexcept -> const Environment* { return environment_; }
-
-  [[nodiscard]] auto inline is_top_level() const noexcept -> bool { return this->container() == nullptr; }
-
-  virtual void startup() = 0;
-  virtual void shutdown() = 0;
-};
-
 class Reactor : public ReactorElement { // NOLINT
 private:
   std::set<BaseAction*> actions_{};
@@ -59,6 +26,7 @@ private:
   std::set<BasePort*> outputs_{};
   std::set<Reaction*> reactions_{};
   std::set<Reactor*> reactors_{};
+  std::set<std::unique_ptr<BaseAction>> connections_{};
 
   void register_action(BaseAction* action);
   void register_input(BasePort* port);
@@ -71,11 +39,13 @@ public:
   Reactor(const std::string& name, Environment* environment);
   ~Reactor() override = default;
 
+  void register_connection(BaseAction* connection);
   [[nodiscard]] auto inline actions() const noexcept -> const auto& { return actions_; }
   [[nodiscard]] auto inline inputs() const noexcept -> const auto& { return inputs_; }
   [[nodiscard]] auto inline outputs() const noexcept -> const auto& { return outputs_; }
   [[nodiscard]] auto inline reactions() const noexcept -> const auto& { return reactions_; }
   [[nodiscard]] auto inline reactors() const noexcept -> const auto& { return reactors_; }
+  [[nodiscard]] auto inline number_of_connections() const noexcept -> std::size_t { return connections_.size(); }
 
   void startup() final;
   void shutdown() final;

--- a/include/reactor-cpp/reactor.hh
+++ b/include/reactor-cpp/reactor.hh
@@ -39,7 +39,7 @@ public:
   Reactor(const std::string& name, Environment* environment);
   ~Reactor() override = default;
 
-  void register_connection(BaseAction* connection);
+  void register_connection(std::unique_ptr<BaseAction>&& connection);
   [[nodiscard]] auto inline actions() const noexcept -> const auto& { return actions_; }
   [[nodiscard]] auto inline inputs() const noexcept -> const auto& { return inputs_; }
   [[nodiscard]] auto inline outputs() const noexcept -> const auto& { return outputs_; }

--- a/include/reactor-cpp/reactor_element.hh
+++ b/include/reactor-cpp/reactor_element.hh
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 TU Dresden
+ * All rights reserved.
+ *
+ * Authors:
+ *   Tassilo Tanneberger
+ *   Christian Menard
+ */
+
+#ifndef REACTOR_CPP_REACTOR_ELEMENT_HH
+#define REACTOR_CPP_REACTOR_ELEMENT_HH
+
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "fwd.hh"
+
+namespace reactor {
+class ReactorElement { // NOLINT
+private:
+  const std::string name_{};
+  std::string fqn_{};
+
+  // The reactor owning this element
+  Reactor* const container_{nullptr};
+  Environment* environment_{};
+
+  auto fqn_detail(std::stringstream& string_stream) const noexcept -> std::stringstream&;
+
+public:
+  enum class Type { Action, Port, Reaction, Reactor, Input, Output };
+
+  ReactorElement(const std::string& name, Type type, Reactor* container);
+  ReactorElement(const std::string& name, Type type, Environment* environment);
+  virtual ~ReactorElement() = default;
+
+  // not copyable, but movable
+  ReactorElement(const ReactorElement&) = delete;
+  ReactorElement(ReactorElement&&) = default;
+
+  [[nodiscard]] auto container() const noexcept -> Reactor* { return container_; }
+
+  [[nodiscard]] auto inline name() const noexcept -> const std::string& { return name_; }
+  [[nodiscard]] auto inline fqn() const noexcept -> const std::string& { return fqn_; }
+  [[nodiscard]] auto inline environment() noexcept -> Environment* { return environment_; }
+  [[nodiscard]] auto inline environment() const noexcept -> const Environment* { return environment_; }
+
+  [[nodiscard]] auto inline is_top_level() const noexcept -> bool { return this->container() == nullptr; }
+
+  virtual void startup() = 0;
+  virtual void shutdown() = 0;
+};
+} // namespace reactor
+
+#endif // REACTOR_CPP_REACTOR_ELEMENT_HH

--- a/include/reactor-cpp/scheduler.hh
+++ b/include/reactor-cpp/scheduler.hh
@@ -69,7 +69,7 @@ private:
   std::atomic<std::ptrdiff_t> size_{0};
   Semaphore sem_{0};
   std::ptrdiff_t waiting_workers_{0};
-  const std::ptrdiff_t num_workers_;
+  const std::ptrdiff_t num_workers_{};
   log::NamedLogger& log_;
 
 public:
@@ -103,12 +103,12 @@ using ActionListPtr = std::unique_ptr<ActionList>;
 
 class EventQueue {
 private:
-  std::shared_mutex mutex_;
-  std::map<Tag, ActionListPtr> event_queue_;
+  std::shared_mutex mutex_{};
+  std::map<Tag, ActionListPtr> event_queue_{};
   /// stores the actions triggered at the current tag
   ActionListPtr triggered_actions_{nullptr};
 
-  std::vector<ActionListPtr> action_list_pool_;
+  std::vector<ActionListPtr> action_list_pool_{};
   static constexpr std::size_t action_list_pool_increment_{10};
 
   void fill_action_list_pool();
@@ -136,20 +136,20 @@ private:
   const bool using_workers_;
   LogicalTime logical_time_{};
 
-  Environment* environment_;
+  Environment* environment_{nullptr};
   std::vector<Worker> workers_{};
   log::NamedLogger log_;
 
-  std::mutex scheduling_mutex_;
-  std::condition_variable cv_schedule_;
+  std::mutex scheduling_mutex_{};
+  std::condition_variable cv_schedule_{};
 
   EventQueue event_queue_;
   /// stores the actions triggered at the current tag
   ActionListPtr triggered_actions_{nullptr};
 
-  std::vector<std::vector<BasePort*>> set_ports_;
-  std::vector<std::vector<Reaction*>> triggered_reactions_;
-  std::vector<std::vector<Reaction*>> reaction_queue_;
+  std::vector<std::vector<BasePort*>> set_ports_{};
+  std::vector<std::vector<Reaction*>> triggered_reactions_{};
+  std::vector<std::vector<Reaction*>> reaction_queue_{};
   unsigned int reaction_queue_pos_{std::numeric_limits<unsigned>::max()};
 
   ReadyQueue ready_queue_;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCE_FILES
     scheduler.cc
     time.cc
     multiport.cc
+    reactor_element.cc
     )
 
 if(REACTOR_CPP_TRACE)

--- a/lib/action.cc
+++ b/lib/action.cc
@@ -15,6 +15,13 @@
 
 namespace reactor {
 
+BaseAction::BaseAction(const std::string& name, Environment* environment, bool logical, Duration min_delay)
+    : ReactorElement(name, ReactorElement::Type::Action, environment)
+    , min_delay_(min_delay)
+    , logical_(logical) {
+  environment->register_input_action(this);
+}
+
 void BaseAction::register_trigger(Reaction* reaction) {
   reactor_assert(reaction != nullptr);
   reactor_assert(this->environment() == reaction->environment());
@@ -93,6 +100,13 @@ auto Action<void>::schedule_at(const Tag& tag) -> bool {
     return scheduler->schedule_async_at(this, tag);
   }
   return true;
+}
+
+auto BaseAction::acquire_tag(const Tag& tag, std::unique_lock<std::mutex>& lock,
+                             const std::function<bool(void)>& abort_waiting) -> bool {
+  reactor_assert(!logical_);
+  reactor_assert(lock.owns_lock());
+  return PhysicalTimeBarrier::acquire_tag(tag, lock, environment()->scheduler(), abort_waiting);
 }
 
 } // namespace reactor

--- a/lib/assert.cc
+++ b/lib/assert.cc
@@ -8,6 +8,7 @@
 
 #include "reactor-cpp/assert.hh"
 #include "reactor-cpp/environment.hh"
+#include "reactor-cpp/reactor_element.hh"
 
 namespace reactor {
 

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -24,7 +24,7 @@
 
 namespace reactor {
 
-Environment::Environment(unsigned int num_workers, bool fast_fwd_execution, const Duration& timeout) // NOLINT
+Environment::Environment(unsigned int num_workers, bool fast_fwd_execution, const Duration& timeout)
     : log_("Environment")
     , num_workers_(num_workers)
     , fast_fwd_execution_(fast_fwd_execution)
@@ -72,15 +72,6 @@ void recursive_assemble(Reactor* container) { // NOLINT
   for (auto* reactor : container->reactors()) {
     recursive_assemble(reactor);
   }
-}
-
-void Environment::register_port(BasePort* port) noexcept {
-  if (top_environment_ == nullptr || top_environment_ == this) {
-    ports_.insert(port);
-    return;
-  }
-
-  return top_environment_->register_port(port);
 }
 
 void Environment::assemble() { // NOLINT
@@ -132,13 +123,13 @@ void Environment::assemble() { // NOLINT
             }
           }
           for (auto& [env, sinks_same_env] : collector) {
-            source_port->pull_connection(properties, sinks_same_env);
+            source_port->instantiate_connection_to(properties, sinks_same_env);
 
             log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks_same_env.size()
                          << " objects";
           }
         } else {
-          source_port->pull_connection(properties, sinks);
+          source_port->instantiate_connection_to(properties, sinks);
 
           log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks.size() << " objects";
         }
@@ -146,7 +137,7 @@ void Environment::assemble() { // NOLINT
     }
   }
 
-  log::Debug() << "Building the Graph";
+  log::Debug() << "Building the Dependency-Graph";
   for (auto* reactor : top_level_reactors_) {
     build_dependency_graph(reactor);
   }
@@ -222,7 +213,7 @@ void Environment::sync_shutdown() {
 }
 
 void Environment::async_shutdown() {
-  scheduler_.lock();
+  [[maybe_unused]] auto lock_guard = scheduler_.lock();
   sync_shutdown();
 }
 

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -74,15 +74,6 @@ void recursive_assemble(Reactor* container) { // NOLINT
   }
 }
 
-void Environment::draw_connection(BasePort* source, BasePort* sink, ConnectionProperties properties) {
-  if (top_environment_ == nullptr || top_environment_ == this) {
-    log::Debug() << "drawing connection: " << source << " --> " << sink;
-    graph_.add_edge(source, sink, properties);
-  } else {
-    top_environment_->draw_connection(source, sink, properties);
-  }
-}
-
 void Environment::register_port(BasePort* port) noexcept {
   if (top_environment_ == nullptr || top_environment_ == this) {
     ports_.insert(port);

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -24,7 +24,7 @@
 
 namespace reactor {
 
-Environment::Environment(unsigned int num_workers, bool fast_fwd_execution, const Duration& timeout)
+Environment::Environment(unsigned int num_workers, bool fast_fwd_execution, const Duration& timeout) //NOLINT
     : log_("Environment")
     , num_workers_(num_workers)
     , fast_fwd_execution_(fast_fwd_execution)
@@ -96,7 +96,7 @@ void Environment::register_port(BasePort* port) noexcept {
   return top_environment_->register_port(port);
 }
 
-void Environment::assemble() {
+void Environment::assemble() { //NOLINT
   phase_ = Phase::Assembly;
 
   // constructing all the reactors
@@ -119,11 +119,11 @@ void Environment::assemble() {
     // this generates the port graph
     for (auto const& [source, sinks] : graph) {
 
-      auto source_port = source.first;
+      auto *source_port = source.first;
       auto properties = source.second;
 
       if (properties.type_ == ConnectionType::Normal) {
-        for (const auto destination_port : sinks) {
+        for (auto *const destination_port : sinks) {
           destination_port->set_inward_binding(source_port);
           source_port->add_outward_binding(destination_port);
           log::Debug() << "from: " << source_port->fqn() << "(" << source_port << ")"
@@ -147,7 +147,7 @@ void Environment::assemble() {
           for (auto& [env, sinks_same_env] : collector) {
             source_port->pull_connection(properties, sinks_same_env);
 
-            log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks.size() << " objects";
+            log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks_same_env.size() << " objects";
           }
         } else {
           source_port->pull_connection(properties, sinks);
@@ -234,7 +234,7 @@ void Environment::sync_shutdown() {
 }
 
 void Environment::async_shutdown() {
-  auto lock_guard = scheduler_.lock();
+  scheduler_.lock();
   sync_shutdown();
 }
 

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -74,10 +74,6 @@ void recursive_assemble(Reactor* container) { // NOLINT
   }
 }
 
-void Environment::draw_connection(BasePort& source, BasePort& sink, ConnectionProperties properties) {
-  this->draw_connection(&source, &sink, properties);
-}
-
 void Environment::draw_connection(BasePort* source, BasePort* sink, ConnectionProperties properties) {
   if (top_environment_ == nullptr || top_environment_ == this) {
     log::Debug() << "drawing connection: " << source << " --> " << sink;

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -24,7 +24,7 @@
 
 namespace reactor {
 
-Environment::Environment(unsigned int num_workers, bool fast_fwd_execution, const Duration& timeout) //NOLINT
+Environment::Environment(unsigned int num_workers, bool fast_fwd_execution, const Duration& timeout) // NOLINT
     : log_("Environment")
     , num_workers_(num_workers)
     , fast_fwd_execution_(fast_fwd_execution)
@@ -96,7 +96,7 @@ void Environment::register_port(BasePort* port) noexcept {
   return top_environment_->register_port(port);
 }
 
-void Environment::assemble() { //NOLINT
+void Environment::assemble() { // NOLINT
   phase_ = Phase::Assembly;
 
   // constructing all the reactors
@@ -119,11 +119,11 @@ void Environment::assemble() { //NOLINT
     // this generates the port graph
     for (auto const& [source, sinks] : graph) {
 
-      auto *source_port = source.first;
+      auto* source_port = source.first;
       auto properties = source.second;
 
       if (properties.type_ == ConnectionType::Normal) {
-        for (auto *const destination_port : sinks) {
+        for (auto* const destination_port : sinks) {
           destination_port->set_inward_binding(source_port);
           source_port->add_outward_binding(destination_port);
           log::Debug() << "from: " << source_port->fqn() << "(" << source_port << ")"
@@ -147,7 +147,8 @@ void Environment::assemble() { //NOLINT
           for (auto& [env, sinks_same_env] : collector) {
             source_port->pull_connection(properties, sinks_same_env);
 
-            log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks_same_env.size() << " objects";
+            log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks_same_env.size()
+                         << " objects";
           }
         } else {
           source_port->pull_connection(properties, sinks);

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -130,11 +130,12 @@ void Environment::assemble() {
                        << " --> to: " << destination_port->fqn() << "(" << destination_port << ")";
         }
       } else {
-        if (properties.type_ == ConnectionType::Enclaved || properties.type_ == ConnectionType::PhysicalEnclaved or properties.type_ == ConnectionType::DelayedEnclaved) {
+        if (properties.type_ == ConnectionType::Enclaved || properties.type_ == ConnectionType::PhysicalEnclaved or
+            properties.type_ == ConnectionType::DelayedEnclaved) {
           // here we need to bundle the downstream ports by their enclave
           std::map<Environment*, std::vector<BasePort*>> collector{};
 
-          for (auto *downstream : sinks) {
+          for (auto* downstream : sinks) {
             if (collector.find(downstream->environment()) == std::end(collector)) {
               // didn't find the enviroment in collector yet
               collector.insert(std::make_pair(downstream->environment(), std::vector<BasePort*>{downstream}));
@@ -146,14 +147,12 @@ void Environment::assemble() {
           for (auto& [env, sinks_same_env] : collector) {
             source_port->pull_connection(properties, sinks_same_env);
 
-            log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks.size()
-                         << " objects";
+            log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks.size() << " objects";
           }
         } else {
           source_port->pull_connection(properties, sinks);
 
-          log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks.size()
-                       << " objects";
+          log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks.size() << " objects";
         }
       }
     }

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -62,6 +62,11 @@ void Environment::register_input_action(BaseAction* action) {
   run_forever_ = true;
 }
 
+void Environment::optimize() {
+  // no optimizations
+  optimized_graph_ = graph_;
+}
+
 void recursive_assemble(Reactor* container) { // NOLINT
   container->assemble();
   for (auto* reactor : container->reactors()) {
@@ -69,21 +74,99 @@ void recursive_assemble(Reactor* container) { // NOLINT
   }
 }
 
+void Environment::draw_connection(BasePort& source, BasePort& sink, ConnectionProperties properties) {
+  this->draw_connection(&source, &sink, properties);
+}
+
+void Environment::draw_connection(BasePort* source, BasePort* sink, ConnectionProperties properties) {
+  if (top_environment_ == nullptr || top_environment_ == this) {
+    log::Debug() << "drawing connection: " << source << " --> " << sink;
+    graph_.add_edge(source, sink, properties);
+  } else {
+    top_environment_->draw_connection(source, sink, properties);
+  }
+}
+
+void Environment::register_port(BasePort* port) noexcept {
+  if (top_environment_ == nullptr || top_environment_ == this) {
+    ports_.insert(port);
+    return;
+  }
+
+  return top_environment_->register_port(port);
+}
+
 void Environment::assemble() {
-  log_.debug() << "Assemble";
-  validate(this->phase() == Phase::Construction, "assemble() may only be called during construction phase!");
   phase_ = Phase::Assembly;
+
+  // constructing all the reactors
+  // this mainly tell the reactors that they should connect their ports and actions not ports and ports
+
+  log::Debug() << "start assembly of reactors";
   for (auto* reactor : top_level_reactors_) {
     recursive_assemble(reactor);
   }
 
-  // build the dependency graph
+  log::Debug() << "start optimization on port graph";
+  this->optimize();
+
+  log::Debug() << "instantiating port graph declaration";
+  if (top_environment_ == nullptr || top_environment_ == this) {
+    log::Debug() << "graph: ";
+    log::Debug() << optimized_graph_;
+
+    auto graph = optimized_graph_.get_edges();
+    // this generates the port graph
+    for (auto const& [source, sinks] : graph) {
+
+      auto source_port = source.first;
+      auto properties = source.second;
+
+      if (properties.type_ == ConnectionType::Normal) {
+        for (const auto destination_port : sinks) {
+          destination_port->set_inward_binding(source_port);
+          source_port->add_outward_binding(destination_port);
+          log::Debug() << "from: " << source_port->fqn() << "(" << source_port << ")"
+                       << " --> to: " << destination_port->fqn() << "(" << destination_port << ")";
+        }
+      } else {
+        if (properties.type_ == ConnectionType::Enclaved || properties.type_ == ConnectionType::PhysicalEnclaved or properties.type_ == ConnectionType::DelayedEnclaved) {
+          // here we need to bundle the downstream ports by their enclave
+          std::map<Environment*, std::vector<BasePort*>> collector{};
+
+          for (auto *downstream : sinks) {
+            if (collector.find(downstream->environment()) == std::end(collector)) {
+              // didn't find the enviroment in collector yet
+              collector.insert(std::make_pair(downstream->environment(), std::vector<BasePort*>{downstream}));
+            } else {
+              // environment already contained in collector
+              collector[downstream->environment()].push_back(downstream);
+            }
+          }
+          for (auto& [env, sinks_same_env] : collector) {
+            source_port->pull_connection(properties, sinks_same_env);
+
+            log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks.size()
+                         << " objects";
+          }
+        } else {
+          source_port->pull_connection(properties, sinks);
+
+          log::Debug() << "from: " << source_port->container()->fqn() << " |-> to: " << sinks.size()
+                       << " objects";
+        }
+      }
+    }
+  }
+
+  log::Debug() << "Building the Graph";
   for (auto* reactor : top_level_reactors_) {
     build_dependency_graph(reactor);
   }
+
   calculate_indexes();
 
-  // assemble all contained environments
+  // this assembles all the contained environments aka enclaves
   for (auto* env : contained_environments_) {
     env->assemble();
   }

--- a/lib/environment.cc
+++ b/lib/environment.cc
@@ -130,7 +130,7 @@ void Environment::assemble() { // NOLINT
                        << " --> to: " << destination_port->fqn() << "(" << destination_port << ")";
         }
       } else {
-        if (properties.type_ == ConnectionType::Enclaved || properties.type_ == ConnectionType::PhysicalEnclaved or
+        if (properties.type_ == ConnectionType::Enclaved || properties.type_ == ConnectionType::PhysicalEnclaved ||
             properties.type_ == ConnectionType::DelayedEnclaved) {
           // here we need to bundle the downstream ports by their enclave
           std::map<Environment*, std::vector<BasePort*>> collector{};

--- a/lib/port.cc
+++ b/lib/port.cc
@@ -92,34 +92,29 @@ void Port<void>::instantiate_connection_to(const ConnectionProperties& propertie
   auto index = this->container()->number_of_connections();
 
   if (properties.type_ == ConnectionType::Delayed) {
-    connection =
-        std::make_unique<DelayedConnection<void>>(this->name() + "_delayed_connection_" + std::to_string(index),
-                                                  this->container(),  // NOLINT
-                                                  properties.delay_); // NOLINT
+    connection = std::make_unique<DelayedConnection<void>>(
+        this->name() + "_delayed_connection_" + std::to_string(index), this->container(), properties.delay_);
   }
   if (properties.type_ == ConnectionType::Physical) {
-    connection =
-        std::make_unique<PhysicalConnection<void>>(this->name() + "_physical_connection_" + std::to_string(index),
-                                                   this->container(),  // NOLINT
-                                                   properties.delay_); // NOLINT
+    connection = std::make_unique<PhysicalConnection<void>>(
+        this->name() + "_physical_connection_" + std::to_string(index), this->container(), properties.delay_);
   }
   if (properties.type_ == ConnectionType::Enclaved) {
     connection = std::make_unique<EnclaveConnection<void>>(
-        this->name() + "_enclave_connection_" + std::to_string(index), enclave); // NOLINT
+        this->name() + "_enclave_connection_" + std::to_string(index), enclave);
   }
   if (properties.type_ == ConnectionType::DelayedEnclaved) {
     connection = std::make_unique<DelayedEnclaveConnection<void>>(
-        this->name() + "_delayed_enclave_connection_" + std::to_string(index), enclave, // NOLINT
-        properties.delay_);                                                             // NOLINT
+        this->name() + "_delayed_enclave_connection_" + std::to_string(index), enclave, properties.delay_);
   }
   if (properties.type_ == ConnectionType::PhysicalEnclaved) {
     connection = std::make_unique<PhysicalEnclaveConnection<void>>(
-        this->name() + "_physical_enclave_connection_" + std::to_string(index), enclave); // NOLINT
+        this->name() + "_physical_enclave_connection_" + std::to_string(index), enclave);
   }
 
   // if the connection here is null we have a vaulty enum value
   reactor_assert(connection != nullptr);
-  connection->bind_downstream_ports(downstream); // NOLINT Pointer is not null
+  connection->bind_downstream_ports(downstream);
   connection->bind_upstream_port(this);
   this->register_set_callback(connection->upstream_set_callback());
   this->container()->register_connection(std::move(connection));

--- a/lib/port.cc
+++ b/lib/port.cc
@@ -12,41 +12,9 @@
 #include "reactor-cpp/environment.hh"
 #include "reactor-cpp/reaction.hh"
 #include "reactor-cpp/statistics.hh"
+#include "reactor-cpp/connection.hh"
 
 namespace reactor {
-
-void BasePort::base_bind_to(BasePort* port) {
-  reactor_assert(port != nullptr);
-  reactor_assert(this->environment() == port->environment());
-  validate(!port->has_inward_binding(), "Ports may only be connected once");
-  validate(!port->has_anti_dependencies(), "Ports with anti dependencies may not be connected to other ports");
-  assert_phase(this, Phase::Assembly);
-  if (this->is_input() && port->is_input()) {
-    validate(this->container() == port->container()->container(),
-             "An input port A may only be bound to another input port B if B is contained by a reactor that in turn is "
-             "contained by the reactor of A");
-  } else if (this->is_input() && port->is_output()) {
-    validate(
-        this->container() == port->container(),
-        "An input port A may only be bound directly to an output port B if A and B are contained by the same reactor.");
-  } else if (this->is_output() && port->is_input()) {
-    validate(this->container()->container() == port->container()->container(),
-             "An output port can only be bound to an input port if both ports belong to reactors in the same "
-             "hierarichal level");
-  } else if (this->is_output() && port->is_output()) {
-    validate(this->container()->container() == port->container(),
-             "An output port A may only be bound to another output port B if A is contained by a reactor that in turn "
-             "is contained by the reactor of B");
-  } else {
-    throw std::runtime_error("invalid connection");
-  }
-
-  port->inward_binding_ = this;
-  [[maybe_unused]] bool result = this->outward_bindings_.insert(port).second;
-  reactor_assert(result);
-
-  Statistics::increment_connections();
-}
 
 void BasePort::register_dependency(Reaction* reaction, bool is_trigger) noexcept {
   reactor_assert(reaction != nullptr);
@@ -107,6 +75,51 @@ void Port<void>::set() {
   auto* scheduler = environment()->scheduler();
   scheduler->set_port(this);
   this->present_ = true;
+}
+
+void Port<void>::pull_connection(const ConnectionProperties& properties, const std::vector<BasePort*>& downstream) {
+  Connection<void>* connection = nullptr;
+
+  if (downstream.empty()) {
+    return;
+  }
+
+  // normal connections should be handled by environment
+  reactor_assert(properties.type_ != ConnectionType::Normal);
+
+  Environment* enclave = downstream[0]->environment();
+  auto index = this->container()->number_of_connections();
+
+  if (properties.type_ == ConnectionType::Delayed) {
+    connection = new DelayedConnection<void>(this->name() + "_delayed_connection_" + std::to_string(index),
+                                             this->container(),  // NOLINT
+                                             properties.delay_); // NOLINT
+  }
+  if (properties.type_ == ConnectionType::Physical) {
+    connection = new PhysicalConnection<void>(this->name() + "_physical_connection_" + std::to_string(index),
+                                              this->container(),  // NOLINT
+                                              properties.delay_); // NOLINT
+  }
+  if (properties.type_ == ConnectionType::Enclaved) {
+    connection =
+        new EnclaveConnection<void>(this->name() + "_enclave_connection_" + std::to_string(index), enclave); // NOLINT
+  }
+  if (properties.type_ == ConnectionType::DelayedEnclaved) {
+    connection = new DelayedEnclaveConnection<void>(
+        this->name() + "_delayed_enclave_connection_" + std::to_string(index), enclave, // NOLINT
+        properties.delay_);                                                             // NOLINT
+  }
+  if (properties.type_ == ConnectionType::PhysicalEnclaved) {
+    connection = new PhysicalEnclaveConnection<void>(
+        this->name() + "_physical_enclave_connection_" + std::to_string(index), enclave); // NOLINT
+  }
+
+  // if the connection here is null we have a vaulty enum value
+  reactor_assert(connection != nullptr);
+  connection->bind_downstream_ports(downstream);
+  connection->bind_upstream_port(this);
+  this->register_set_callback(connection->upstream_set_callback());
+  this->container()->register_connection(connection);
 }
 
 // This function can be used to chain two callbacks. This mechanism is not

--- a/lib/port.cc
+++ b/lib/port.cc
@@ -116,7 +116,7 @@ void Port<void>::pull_connection(const ConnectionProperties& properties, const s
 
   // if the connection here is null we have a vaulty enum value
   reactor_assert(connection != nullptr);
-  connection->bind_downstream_ports(downstream);
+  connection->bind_downstream_ports(downstream); //NOLINT Pointer is not null
   connection->bind_upstream_port(this);
   this->register_set_callback(connection->upstream_set_callback());
   this->container()->register_connection(connection);

--- a/lib/port.cc
+++ b/lib/port.cc
@@ -9,10 +9,10 @@
 #include "reactor-cpp/port.hh"
 
 #include "reactor-cpp/assert.hh"
+#include "reactor-cpp/connection.hh"
 #include "reactor-cpp/environment.hh"
 #include "reactor-cpp/reaction.hh"
 #include "reactor-cpp/statistics.hh"
-#include "reactor-cpp/connection.hh"
 
 namespace reactor {
 

--- a/lib/port.cc
+++ b/lib/port.cc
@@ -116,7 +116,7 @@ void Port<void>::pull_connection(const ConnectionProperties& properties, const s
 
   // if the connection here is null we have a vaulty enum value
   reactor_assert(connection != nullptr);
-  connection->bind_downstream_ports(downstream); //NOLINT Pointer is not null
+  connection->bind_downstream_ports(downstream); // NOLINT Pointer is not null
   connection->bind_upstream_port(this);
   this->register_set_callback(connection->upstream_set_callback());
   this->container()->register_connection(connection);

--- a/lib/reactor.cc
+++ b/lib/reactor.cc
@@ -71,9 +71,9 @@ void Reactor::register_reactor([[maybe_unused]] Reactor* reactor) {
   Statistics::increment_reactor_instances();
 }
 
-void Reactor::register_connection([[maybe_unused]] BaseAction* connection) {
+void Reactor::register_connection([[maybe_unused]] std::unique_ptr<BaseAction>&& connection) {
   reactor_assert(connection != nullptr);
-  [[maybe_unused]] auto result = connections_.insert(std::unique_ptr<BaseAction>(connection)).second;
+  [[maybe_unused]] auto result = connections_.insert(std::move(connection)).second;
   reactor_assert(result);
 }
 

--- a/lib/reactor.cc
+++ b/lib/reactor.cc
@@ -17,71 +17,6 @@
 #include "reactor-cpp/statistics.hh"
 
 namespace reactor {
-
-ReactorElement::ReactorElement(const std::string& name, ReactorElement::Type type, Reactor* container)
-    : name_(name)
-    , container_(container) {
-  reactor_assert(container != nullptr);
-  this->environment_ = container->environment(); // NOLINT container can be NULL
-  reactor_assert(this->environment_ != nullptr);
-  validate(this->environment_->phase() == Phase::Construction ||
-               (type == Type::Action && this->environment_->phase() == Phase::Assembly),
-           "Reactor elements can only be created during construction phase!");
-  // We need a reinterpret_cast here as the derived class is not yet created
-  // when this constructor is executed. dynamic_cast only works for
-  // completely constructed objects. Technically, the casts here return
-  // invalid pointers as the objects they point to do not yet
-  // exists. However, we are good as long as we only store the pointer and do
-  // not dereference it before construction is completeted.
-  // It works, but maybe there is some nicer way of doing this...
-  switch (type) {
-  case Type::Action:
-    container->register_action(reinterpret_cast<BaseAction*>(this)); // NOLINT
-    break;
-  case Type::Input:
-    container->register_input(reinterpret_cast<BasePort*>(this)); // NOLINT
-    break;
-  case Type::Output:
-    container->register_output(reinterpret_cast<BasePort*>(this)); // NOLINT
-    break;
-  case Type::Reaction:
-    container->register_reaction(reinterpret_cast<Reaction*>(this)); // NOLINT
-    break;
-  case Type::Reactor:
-    container->register_reactor(reinterpret_cast<Reactor*>(this)); // NOLINT
-    break;
-  default:
-    throw std::runtime_error("unexpected type");
-  }
-
-  std::stringstream string_stream;
-  string_stream << container_->fqn() << '.' << name;
-  fqn_ = string_stream.str();
-}
-
-ReactorElement::ReactorElement(const std::string& name, ReactorElement::Type type, Environment* environment)
-    : name_(name)
-    , fqn_(name)
-    , environment_(environment) {
-  reactor_assert(environment != nullptr);
-  validate(type == Type::Reactor || type == Type::Action, "Only reactors and actions can be owned by the environment!");
-
-  switch (type) {
-  case Type::Action:
-    validate(this->environment_->phase() == Phase::Construction || this->environment_->phase() == Phase::Assembly,
-             "Actions can only be created during construction or assembly phase!");
-    Statistics::increment_actions();
-    break;
-  case Type::Reactor:
-    validate(this->environment_->phase() == Phase::Construction,
-             "Reactors can only be created during construction phase!");
-    Statistics::increment_reactor_instances();
-    break;
-  default:
-    break;
-  }
-}
-
 Reactor::Reactor(const std::string& name, Reactor* container)
     : ReactorElement(name, ReactorElement::Type::Reactor, container) {}
 Reactor::Reactor(const std::string& name, Environment* environment)
@@ -134,6 +69,12 @@ void Reactor::register_reactor([[maybe_unused]] Reactor* reactor) {
   [[maybe_unused]] bool result = reactors_.insert(reactor).second;
   reactor_assert(result);
   Statistics::increment_reactor_instances();
+}
+
+void Reactor::register_connection([[maybe_unused]] BaseAction* connection) {
+  reactor_assert(connection != nullptr);
+  [[maybe_unused]] auto result = connections_.insert(std::unique_ptr<BaseAction>(connection)).second;
+  reactor_assert(result);
 }
 
 void Reactor::startup() {

--- a/lib/reactor_element.cc
+++ b/lib/reactor_element.cc
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 TU Dresden
+ * All rights reserved.
+ *
+ * Authors:
+ *   Tassilo Tanneberger
+ *   Christian Menard
+ */
+
+#include "reactor-cpp/reactor.hh"
+
+#include "reactor-cpp/action.hh"
+#include "reactor-cpp/assert.hh"
+#include "reactor-cpp/environment.hh"
+#include "reactor-cpp/port.hh"
+#include "reactor-cpp/reaction.hh"
+#include "reactor-cpp/statistics.hh"
+
+namespace reactor {
+
+ReactorElement::ReactorElement(const std::string& name, ReactorElement::Type type, Reactor* container)
+    : name_(name)
+    , container_(container) {
+  reactor_assert(container != nullptr);
+  this->environment_ = container->environment(); // NOLINT container can be NULL
+  reactor_assert(this->environment_ != nullptr);
+  validate(this->environment_->phase() == Phase::Construction ||
+               (type == Type::Action && this->environment_->phase() == Phase::Assembly),
+           "Reactor elements can only be created during construction phase!");
+  // We need a reinterpret_cast here as the derived class is not yet created
+  // when this constructor is executed. dynamic_cast only works for
+  // completely constructed objects. Technically, the casts here return
+  // invalid pointers as the objects they point to do not yet
+  // exists. However, we are good as long as we only store the pointer and do
+  // not dereference it before construction is completeted.
+  // It works, but maybe there is some nicer way of doing this...
+  switch (type) {
+  case Type::Action:
+    container->register_action(reinterpret_cast<BaseAction*>(this)); // NOLINT
+    break;
+  case Type::Input:
+    container->register_input(reinterpret_cast<BasePort*>(this)); // NOLINT
+    break;
+  case Type::Output:
+    container->register_output(reinterpret_cast<BasePort*>(this)); // NOLINT
+    break;
+  case Type::Reaction:
+    container->register_reaction(reinterpret_cast<Reaction*>(this)); // NOLINT
+    break;
+  case Type::Reactor:
+    container->register_reactor(reinterpret_cast<Reactor*>(this)); // NOLINT
+    break;
+  default:
+    throw std::runtime_error("unexpected type");
+  }
+
+  std::stringstream string_stream;
+  string_stream << container_->fqn() << '.' << name;
+  fqn_ = string_stream.str();
+}
+
+ReactorElement::ReactorElement(const std::string& name, ReactorElement::Type type, Environment* environment)
+    : name_(name)
+    , fqn_(name)
+    , environment_(environment) {
+  reactor_assert(environment != nullptr);
+
+  validate(type == Type::Reactor || type == Type::Action, "Only reactors and actions can be owned by the environment!");
+  validate(this->environment_->phase() == Phase::Construction ||
+               (type == Type::Action && this->environment_->phase() == Phase::Assembly),
+           "Reactor elements can only be created during construction phase!");
+
+  switch (type) {
+  case Type::Action:
+    Statistics::increment_actions();
+    break;
+  case Type::Reactor:
+    Statistics::increment_reactor_instances();
+    break;
+  default:
+    break;
+  }
+}
+} // namespace reactor


### PR DESCRIPTION
# Declarative Port Graph

This pull request is a tremendous refactor of reactor-cpp instead of connecting ports in the assemble methods, this pull requests introduces a way to declarative define the port graph. On this more formal definition of a graph (`PropertyGraph`) I implemented a spanning tree style optimization that figures out all the connected downstream ports. Consequently, this spanning tree is then "flattened" into a tree of depth one in the process all the connections to every leaf of the tree is merged. This merging logic also takes Delayed, Enclaved and Physical connections into consideration. 

## Important Changes for the Code Generator


**Declaring the PortGraph**
```cpp
# connecting up the ports with their identifier 
env.draw_connection(counter1.count, add.i1, ConnectionProperties{});
env.draw_connection(counter2.count, add.i2, ConnectionProperties{});
env.draw_connection(add.sum, p_add.forward, ConnectionProperties{ConnectionType::Delayed, 10s, nullptr});
env.draw_connection(p_add.forward, p_add.value, ConnectionProperties{ConnectionType::Delayed, 5s, nullptr});
```
**Start Up**
```cpp
# first we need to "optimize" the graph this is currently a mandetory 
env.optimize();

# assembeling everything
# 1.) assembeling reactors
# 2.) intantiating port graph
# 3.) calculating dependency graph and calculate reaction indices
env.assemble();

# beginning execution
auto thread = env.startup();
thread.join();
```

