### PR TITLE
Build the dependency graph only after establishing all connections

### DIFF
--- a/include/reactor-cpp/environment.hh
+++ b/include/reactor-cpp/environment.hh
@@ -88,7 +88,7 @@ public:
 
   template <class T> void draw_connection(Port<T>* source, Port<T>* sink, ConnectionProperties properties) {
     if (top_environment_ == nullptr || top_environment_ == this) {
-      log::Debug() << "drawing connection: " << source << " --> " << sink;
+      log::Debug() << "drawing connection: " << source->fqn() << " --> " << sink->fqn();
       graph_.add_edge(source, sink, properties);
     } else {
       top_environment_->draw_connection(source, sink, properties);


### PR DESCRIPTION
This fixes a range of bugs that occur in programs using enclaves. The dependency graph of enclaves was build before all connections were created. This lead to out of order execution for some reactions.

This PR ensures that we first assemble all reactors (also those in enclaves), then construct the connections, and finally analyze dependencies and calculate reaction indices.