### PR TITLE
Fixed bug that arises when enabling tracing in programs with enclaves.

### DIFF
--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -461,10 +461,9 @@ void Scheduler::schedule_sync(BaseAction* action, const Tag& tag) {
   log_.debug() << "Schedule action " << action->fqn() << (action->is_logical() ? " synchronously " : " asynchronously ")
                << " with tag " << tag;
   reactor_assert(logical_time_ < tag);
-  if(action->container()){
+  if (action->container() != 0) {
     tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag);
-  }
-  else{
+  } else {
     tracepoint(reactor_cpp, schedule_action, action->environment()->name(), action->name(), tag);
   }
   Statistics::increment_scheduled_actions();

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -461,7 +461,7 @@ void Scheduler::schedule_sync(BaseAction* action, const Tag& tag) {
   log_.debug() << "Schedule action " << action->fqn() << (action->is_logical() ? " synchronously " : " asynchronously ")
                << " with tag " << tag;
   reactor_assert(logical_time_ < tag);
-  if (action->container() != 0) {
+  if (action->container() != nullptr) {
     tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag);
   } else {
     tracepoint(reactor_cpp, schedule_action, action->environment()->name(), action->name(), tag);

--- a/lib/scheduler.cc
+++ b/lib/scheduler.cc
@@ -461,7 +461,12 @@ void Scheduler::schedule_sync(BaseAction* action, const Tag& tag) {
   log_.debug() << "Schedule action " << action->fqn() << (action->is_logical() ? " synchronously " : " asynchronously ")
                << " with tag " << tag;
   reactor_assert(logical_time_ < tag);
-  tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag);
+  if(action->container()){
+    tracepoint(reactor_cpp, schedule_action, action->container()->fqn(), action->name(), tag);
+  }
+  else{
+    tracepoint(reactor_cpp, schedule_action, action->environment()->name(), action->name(), tag);
+  }
   Statistics::increment_scheduled_actions();
 
   const auto& action_list = event_queue_.insert_event_at(tag);


### PR DESCRIPTION
- Action tracing takes the action container as argument, but in a program with enclaves some of the actions might not have a container, which leads to segmentation fault.
- The bug was fixed by giving the environment name as parameter instead of the container name, for the actions without a container.
- Notice that the bug only arises if a tracing session was started with the ./tracing/start_tracing.sh script, before running the lf program.